### PR TITLE
fix(engine): parallel dispatch guardrails and streaming pool (fixes #65)

### DIFF
--- a/agent_fox/engine/orchestrator.py
+++ b/agent_fox/engine/orchestrator.py
@@ -15,6 +15,7 @@ Requirements: 04-REQ-1.1 through 04-REQ-1.4, 04-REQ-1.E1, 04-REQ-1.E2,
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import signal
@@ -451,44 +452,100 @@ class Orchestrator:
         error_tracker: dict[str, str | None],
         first_dispatch: bool,
     ) -> None:
-        """Dispatch a batch of ready tasks concurrently."""
+        """Dispatch ready tasks using a streaming pool.
+
+        Maintains a pool of up to ``max_parallelism`` concurrent asyncio
+        tasks.  When a task completes, ``ready_tasks()`` is re-evaluated
+        and empty pool slots are filled with newly-unblocked work.
+
+        Only tasks that are *actually running* are marked ``in_progress``
+        — queued tasks remain ``pending`` until a pool slot opens.
+
+        This replaces the former batch-and-wait model which over-committed
+        all ready tasks as ``in_progress`` and delayed newly-unblocked
+        tasks until the entire batch completed.
+        """
         assert self._graph_sync is not None  # noqa: S101
         assert self._parallel_runner is not None  # noqa: S101
 
-        batch: list[tuple[str, int, str | None]] = []
-        for node_id in ready:
-            if self._signal.interrupted:
-                break
+        # Local refs so the nested closure satisfies mypy narrowing.
+        graph_sync = self._graph_sync
+        parallel_runner = self._parallel_runner
 
-            attempt = attempt_tracker.get(node_id, 0) + 1
-            verdict = self._check_launch(node_id, attempt, state, attempt_tracker)
-            if verdict != "allowed":
-                continue
+        pool: set[asyncio.Task[SessionRecord]] = set()
+        max_pool = parallel_runner.max_parallelism
 
-            attempt_tracker[node_id] = attempt
-            self._graph_sync.mark_in_progress(node_id)
-            previous_error = error_tracker.get(node_id)
-            batch.append((node_id, attempt, previous_error))
+        def _fill_pool(candidates: list[str]) -> None:
+            """Launch candidates into the pool up to max_parallelism."""
+            for node_id in candidates:
+                if len(pool) >= max_pool:
+                    break
+                if self._signal.interrupted:
+                    break
 
-        if not batch:
+                attempt = attempt_tracker.get(node_id, 0) + 1
+                verdict = self._check_launch(
+                    node_id, attempt, state, attempt_tracker,
+                )
+                if verdict != "allowed":
+                    continue
+
+                attempt_tracker[node_id] = attempt
+                graph_sync.mark_in_progress(node_id)
+                previous_error = error_tracker.get(node_id)
+
+                task = asyncio.create_task(
+                    parallel_runner.execute_one(
+                        node_id, attempt, previous_error,
+                    ),
+                    name=f"parallel-{node_id}",
+                )
+                pool.add(task)
+
+        _fill_pool(ready)
+
+        if not pool:
             return
 
         # Persist in_progress state so agent-fox status can show it
+        parallel_runner.track_tasks(list(pool))
         self._state_manager.save(state)
 
-        async def on_complete(record: SessionRecord) -> None:
-            self._process_session_result(
-                record,
-                attempt_tracker.get(record.node_id, 1),
-                state,
-                attempt_tracker,
-                error_tracker,
-            )
-            # 06-REQ-6.1: Check sync barrier after task completion
-            if record.status == "completed":
-                self._run_sync_barrier_if_needed(state)
+        while pool:
+            if self._signal.interrupted:
+                break
 
-        await self._parallel_runner.execute_batch(batch, on_complete)
+            # Wait for any task to complete
+            done, pool = await asyncio.wait(
+                pool, return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            for completed_task in done:
+                try:
+                    record = completed_task.result()
+                except Exception as exc:
+                    logger.error("Parallel task raised: %s", exc)
+                    continue
+
+                self._process_session_result(
+                    record,
+                    attempt_tracker.get(record.node_id, 1),
+                    state,
+                    attempt_tracker,
+                    error_tracker,
+                )
+
+                # 06-REQ-6.1: Check sync barrier after task completion
+                if record.status == "completed":
+                    self._run_sync_barrier_if_needed(state)
+
+            # Re-evaluate ready tasks and fill empty pool slots
+            if not self._signal.interrupted:
+                new_ready = graph_sync.ready_tasks()
+                _fill_pool(new_ready)
+
+            parallel_runner.track_tasks(list(pool))
+            self._state_manager.save(state)
 
     def _process_session_result(
         self,

--- a/agent_fox/engine/parallel.py
+++ b/agent_fox/engine/parallel.py
@@ -25,10 +25,16 @@ MAX_PARALLELISM = 8
 class ParallelRunner:
     """Runs up to N tasks concurrently via asyncio.
 
-    Uses an asyncio.Semaphore to limit the number of concurrent sessions
-    to the configured ``max_parallelism`` (capped at 8). State writes
-    via the ``on_complete`` callback are serialized under an asyncio.Lock
-    to prevent interleaved writes.
+    Supports two execution models:
+
+    - **Batch** (``execute_batch``): Launch all tasks at once, bounded by a
+      semaphore. Waits for all to complete before returning.  Used by tests.
+    - **Streaming pool** (``execute_one`` + external pool management): The
+      orchestrator manages a pool of asyncio tasks, launching new ones as
+      slots open after each completion.  Preferred at runtime.
+
+    State writes via completion callbacks are serialized under an
+    ``asyncio.Lock`` to prevent interleaved writes.
     """
 
     def __init__(
@@ -61,6 +67,55 @@ class ParallelRunner:
         self._inter_session_delay = inter_session_delay
         self._state_lock = asyncio.Lock()
         self._in_flight_tasks: list[asyncio.Task[SessionRecord]] = []
+
+    @property
+    def max_parallelism(self) -> int:
+        """Return the effective maximum parallelism."""
+        return self._max_parallelism
+
+    async def execute_one(
+        self,
+        node_id: str,
+        attempt: int,
+        previous_error: str | None,
+    ) -> SessionRecord:
+        """Execute a single session and return the record.
+
+        This is the building block for streaming pool dispatch.
+        The orchestrator wraps this in an ``asyncio.Task`` and manages
+        the pool externally.
+
+        Args:
+            node_id: The task graph node to execute.
+            attempt: The attempt number (1-indexed).
+            previous_error: Error message from prior attempt, if any.
+
+        Returns:
+            A SessionRecord with outcome, cost, and timing.
+        """
+        try:
+            return await self._execute_session(node_id, attempt, previous_error)
+        except Exception as exc:
+            logger.error(
+                "Task %s failed with exception: %s",
+                node_id,
+                exc,
+            )
+            return SessionRecord(
+                node_id=node_id,
+                attempt=attempt,
+                status="failed",
+                input_tokens=0,
+                output_tokens=0,
+                cost=0.0,
+                duration_ms=0,
+                error_message=str(exc),
+                timestamp=datetime.now(UTC).isoformat(),
+            )
+
+    def track_tasks(self, tasks: list[asyncio.Task[SessionRecord]]) -> None:
+        """Update the set of in-flight tasks (for SIGINT cancellation)."""
+        self._in_flight_tasks = list(tasks)
 
     async def execute_batch(
         self,

--- a/agent_fox/engine/sync.py
+++ b/agent_fox/engine/sync.py
@@ -94,8 +94,13 @@ class GraphSync:
             for dependent in self._dependents.get(current, []):
                 if dependent in visited:
                     continue
-                # Only cascade to nodes that are not already completed
-                if self.node_states.get(dependent) in ("completed",):
+                # Skip completed nodes (work is done) and in_progress
+                # nodes (actively executing; their result will be
+                # processed when they finish).
+                if self.node_states.get(dependent) in (
+                    "completed",
+                    "in_progress",
+                ):
                     continue
                 visited.add(dependent)
                 self.node_states[dependent] = "blocked"

--- a/tests/property/engine/test_sync_props.py
+++ b/tests/property/engine/test_sync_props.py
@@ -196,3 +196,40 @@ class TestReadyTaskCorrectness:
                 f"Ready task {ready_node} should be pending but is "
                 f"{sync.node_states[ready_node]}"
             )
+
+
+class TestBatchIndependence:
+    """TS-04-P3: Batch independence for parallel dispatch.
+
+    For any graph state, no task in the ready set depends on another task
+    in the same ready set. This guarantees that all ready tasks can be
+    safely dispatched in parallel without ordering constraints.
+
+    This is a structural invariant of ``ready_tasks()`` — if task A is
+    ready, all its dependencies are completed (not pending), so no other
+    pending (and therefore ready) task is a dependency of A.
+    """
+
+    @given(data=random_dag_with_completed_set())
+    @settings(max_examples=100)
+    def test_ready_tasks_are_pairwise_independent(
+        self,
+        data: tuple[dict[str, str], dict[str, list[str]], set[str]],
+    ) -> None:
+        """No ready task depends on another ready task."""
+        node_states, edges, completed_set = data
+
+        sync = GraphSync(dict(node_states), dict(edges))
+        for nid in completed_set:
+            sync.mark_completed(nid)
+
+        ready = sync.ready_tasks()
+        ready_set = set(ready)
+
+        for ready_node in ready:
+            deps = edges.get(ready_node, [])
+            for dep in deps:
+                assert dep not in ready_set, (
+                    f"Ready task {ready_node} depends on {dep} which is "
+                    f"also in the ready set — batch is not independent"
+                )

--- a/tests/unit/engine/test_orchestrator.py
+++ b/tests/unit/engine/test_orchestrator.py
@@ -1130,3 +1130,221 @@ class TestPlanJsonStatusSync:
         updated_plan = json.loads(plan_path.read_text())
         assert updated_plan["nodes"]["spec:1"]["status"] == "blocked"
         assert updated_plan["nodes"]["spec:2"]["status"] == "blocked"
+
+
+class TestParallelDispatchWithDependencies:
+    """Parallel execution respects dependency ordering.
+
+    Verify that when running in parallel mode, the orchestrator only
+    dispatches tasks whose dependencies are all completed, and that
+    newly-unblocked tasks are dispatched promptly (streaming pool).
+
+    Requirements: 04-REQ-1.3, 04-REQ-6.1, 04-REQ-10.1
+    """
+
+    @pytest.mark.asyncio
+    async def test_dependent_task_runs_after_prerequisite(
+        self,
+        tmp_plan_dir: Path,
+        tmp_state_path: Path,
+        mock_runner: MockSessionRunner,
+    ) -> None:
+        """In parallel mode, B waits for A; C waits for B."""
+        plan_path = write_plan_file(
+            tmp_plan_dir,
+            nodes={
+                "spec:1": {"title": "Task A"},
+                "spec:2": {"title": "Task B"},
+                "spec:3": {"title": "Task C"},
+            },
+            edges=[
+                {"source": "spec:1", "target": "spec:2", "kind": "intra_spec"},
+                {"source": "spec:2", "target": "spec:3", "kind": "intra_spec"},
+            ],
+            order=["spec:1", "spec:2", "spec:3"],
+        )
+
+        config = OrchestratorConfig(parallel=4, inter_session_delay=0)
+        orchestrator = Orchestrator(
+            config=config,
+            plan_path=plan_path,
+            state_path=tmp_state_path,
+            session_runner_factory=lambda nid: mock_runner,
+        )
+
+        state = await orchestrator.run()
+
+        dispatched = [call[0] for call in mock_runner.calls]
+        assert dispatched == ["spec:1", "spec:2", "spec:3"]
+        assert all(s == "completed" for s in state.node_states.values())
+
+    @pytest.mark.asyncio
+    async def test_independent_tasks_dispatched_together(
+        self,
+        tmp_plan_dir: Path,
+        tmp_state_path: Path,
+        mock_runner: MockSessionRunner,
+    ) -> None:
+        """Independent tasks are dispatched in the same pool cycle."""
+        # A -> C, B -> C  (A and B are independent, C depends on both)
+        plan_path = write_plan_file(
+            tmp_plan_dir,
+            nodes={
+                "spec_a:1": {"title": "Task A"},
+                "spec_b:1": {"title": "Task B"},
+                "spec_c:1": {"title": "Task C"},
+            },
+            edges=[
+                {"source": "spec_a:1", "target": "spec_c:1", "kind": "cross_spec"},
+                {"source": "spec_b:1", "target": "spec_c:1", "kind": "cross_spec"},
+            ],
+            order=["spec_a:1", "spec_b:1", "spec_c:1"],
+        )
+
+        config = OrchestratorConfig(parallel=4, inter_session_delay=0)
+        orchestrator = Orchestrator(
+            config=config,
+            plan_path=plan_path,
+            state_path=tmp_state_path,
+            session_runner_factory=lambda nid: mock_runner,
+        )
+
+        state = await orchestrator.run()
+
+        dispatched = [call[0] for call in mock_runner.calls]
+        # A and B should be dispatched before C
+        assert "spec_c:1" == dispatched[-1]
+        assert set(dispatched[:2]) == {"spec_a:1", "spec_b:1"}
+        assert all(s == "completed" for s in state.node_states.values())
+
+    @pytest.mark.asyncio
+    async def test_cascade_block_prevents_dependent_dispatch(
+        self,
+        tmp_plan_dir: Path,
+        tmp_state_path: Path,
+    ) -> None:
+        """When A fails, B (which depends on A) is not dispatched."""
+        plan_path = write_plan_file(
+            tmp_plan_dir,
+            nodes={
+                "spec:1": {"title": "Task A"},
+                "spec:2": {"title": "Task B"},
+            },
+            edges=[
+                {"source": "spec:1", "target": "spec:2", "kind": "intra_spec"},
+            ],
+            order=["spec:1", "spec:2"],
+        )
+
+        mock = MockSessionRunner()
+        mock.configure("spec:1", [
+            MockSessionOutcome(
+                node_id="spec:1", status="failed",
+                error_message="fail",
+            ),
+        ])
+
+        config = OrchestratorConfig(
+            parallel=4, max_retries=0, inter_session_delay=0,
+        )
+        orchestrator = Orchestrator(
+            config=config,
+            plan_path=plan_path,
+            state_path=tmp_state_path,
+            session_runner_factory=lambda nid: mock,
+        )
+
+        state = await orchestrator.run()
+
+        dispatched = [call[0] for call in mock.calls]
+        assert "spec:2" not in dispatched
+        assert state.node_states["spec:1"] == "blocked"
+        assert state.node_states["spec:2"] == "blocked"
+
+    @pytest.mark.asyncio
+    async def test_streaming_pool_dispatches_unblocked_tasks(
+        self,
+        tmp_plan_dir: Path,
+        tmp_state_path: Path,
+        mock_runner: MockSessionRunner,
+    ) -> None:
+        """Streaming pool dispatches newly-ready tasks without waiting
+        for the entire batch to complete.
+
+        Graph: A -> C, B (independent). When A completes, C becomes
+        ready and should be dispatched even if B is still running.
+        All three should complete.
+        """
+        plan_path = write_plan_file(
+            tmp_plan_dir,
+            nodes={
+                "spec_a:1": {"title": "Task A"},
+                "spec_b:1": {"title": "Task B"},
+                "spec_c:1": {"title": "Task C"},
+            },
+            edges=[
+                {"source": "spec_a:1", "target": "spec_c:1", "kind": "cross_spec"},
+            ],
+            order=["spec_a:1", "spec_b:1", "spec_c:1"],
+        )
+
+        config = OrchestratorConfig(parallel=4, inter_session_delay=0)
+        orchestrator = Orchestrator(
+            config=config,
+            plan_path=plan_path,
+            state_path=tmp_state_path,
+            session_runner_factory=lambda nid: mock_runner,
+        )
+
+        state = await orchestrator.run()
+
+        assert state.total_sessions == 3
+        assert all(s == "completed" for s in state.node_states.values())
+
+    @pytest.mark.asyncio
+    async def test_pool_bounded_by_max_parallelism(
+        self,
+        tmp_plan_dir: Path,
+        tmp_state_path: Path,
+    ) -> None:
+        """Only max_parallelism tasks are in_progress at any given time.
+
+        With 6 independent tasks and parallelism=2, at most 2 tasks
+        should be in_progress simultaneously.
+        """
+        plan_path = write_plan_file(
+            tmp_plan_dir,
+            nodes={f"spec:{i}": {"title": f"Task {i}"} for i in range(1, 7)},
+            edges=[],
+        )
+
+        max_concurrent = 0
+        current_concurrent = 0
+
+        class ConcurrencyTracker(MockSessionRunner):
+            async def execute(
+                self,
+                node_id: str,
+                attempt: int,
+                previous_error: str | None = None,
+            ) -> MockSessionOutcome:
+                nonlocal max_concurrent, current_concurrent
+                current_concurrent += 1
+                max_concurrent = max(max_concurrent, current_concurrent)
+                result = await super().execute(node_id, attempt, previous_error)
+                current_concurrent -= 1
+                return result
+
+        mock = ConcurrencyTracker()
+        config = OrchestratorConfig(parallel=2, inter_session_delay=0)
+        orchestrator = Orchestrator(
+            config=config,
+            plan_path=plan_path,
+            state_path=tmp_state_path,
+            session_runner_factory=lambda nid: mock,
+        )
+
+        state = await orchestrator.run()
+
+        assert state.total_sessions == 6
+        assert max_concurrent <= 2

--- a/tests/unit/engine/test_parallel.py
+++ b/tests/unit/engine/test_parallel.py
@@ -295,3 +295,76 @@ class TestFewerTasksThanParallelism:
 
         assert len(records) == 1
         assert records[0].node_id == "A"
+
+
+class TestExecuteOne:
+    """Tests for the execute_one method used by streaming pool dispatch."""
+
+    @pytest.mark.asyncio
+    async def test_execute_one_returns_record(self) -> None:
+        """execute_one returns a SessionRecord on success."""
+        mock = MockParallelSessionRunner(delay=0.01)
+        runner = ParallelRunner(
+            session_runner_factory=lambda nid: mock,
+            max_parallelism=4,
+            inter_session_delay=0,
+        )
+
+        record = await runner.execute_one("A", 1, None)
+
+        assert record.node_id == "A"
+        assert record.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_execute_one_handles_exception(self) -> None:
+        """execute_one returns a failed record on exception."""
+
+        class FailingRunner:
+            async def execute(
+                self,
+                node_id: str,
+                attempt: int,
+                previous_error: str | None = None,
+            ) -> SessionRecord:
+                raise RuntimeError("session crashed")
+
+        runner = ParallelRunner(
+            session_runner_factory=lambda nid: FailingRunner(),
+            max_parallelism=4,
+            inter_session_delay=0,
+        )
+
+        record = await runner.execute_one("A", 1, None)
+
+        assert record.node_id == "A"
+        assert record.status == "failed"
+        assert "session crashed" in (record.error_message or "")
+
+    @pytest.mark.asyncio
+    async def test_track_tasks_updates_in_flight(self) -> None:
+        """track_tasks updates the in-flight task list for cancellation."""
+        mock = MockParallelSessionRunner(delay=0.5)
+        runner = ParallelRunner(
+            session_runner_factory=lambda nid: mock,
+            max_parallelism=4,
+            inter_session_delay=0,
+        )
+
+        task = asyncio.create_task(runner.execute_one("A", 1, None))
+        runner.track_tasks([task])
+
+        assert len(runner._in_flight_tasks) == 1
+
+        await runner.cancel_all()
+
+        assert len(runner._in_flight_tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_max_parallelism_property(self) -> None:
+        """max_parallelism property returns the effective value."""
+        runner = ParallelRunner(
+            session_runner_factory=lambda nid: MockParallelSessionRunner(),
+            max_parallelism=3,
+            inter_session_delay=0,
+        )
+        assert runner.max_parallelism == 3

--- a/tests/unit/engine/test_sync.py
+++ b/tests/unit/engine/test_sync.py
@@ -125,6 +125,35 @@ class TestCascadeBlockingLinear:
 
         assert sync.node_states["A"] == "completed"
 
+    def test_in_progress_tasks_not_cascade_blocked(self) -> None:
+        """In-progress tasks are not affected by cascade blocking.
+
+        Tasks that are actively executing should finish their session;
+        their result is processed when they complete.
+        """
+        # Graph: A -> B, A -> C, B -> D, C -> D
+        # A is completed, B fails and is blocked, C is in_progress
+        node_states = {
+            "A": "completed",
+            "B": "pending",
+            "C": "in_progress",
+            "D": "pending",
+        }
+        # D depends on both B and C
+        edges = {"B": ["A"], "C": ["A"], "D": ["B", "C"]}
+
+        sync = GraphSync(node_states, edges)
+        cascade_blocked = sync.mark_blocked("B", "retries exhausted")
+
+        # C is in_progress and should NOT be cascade-blocked
+        assert sync.node_states["C"] == "in_progress"
+        assert "C" not in cascade_blocked
+
+        # D depends on B (blocked), but D also depends on C (in_progress).
+        # D should be cascade-blocked because B is blocked.
+        assert sync.node_states["D"] == "blocked"
+        assert "D" in cascade_blocked
+
 
 class TestCascadeBlockingDiamond:
     """TS-04-7: Cascade blocking with diamond dependency.


### PR DESCRIPTION
## Summary

Replaces the batch-and-wait parallel dispatch model with a streaming pool that enforces proper dependency guardrails. Tasks are only marked `in_progress` when they actually start executing (bounded by `max_parallelism`), and newly-unblocked tasks are dispatched immediately when pool slots open — instead of waiting for the entire batch to complete.

Closes #65

## Changes

| File | Change |
|------|--------|
| `agent_fox/engine/orchestrator.py` | Refactor `_dispatch_parallel` from batch-and-wait to streaming pool using `asyncio.wait(FIRST_COMPLETED)`. Re-evaluates `ready_tasks()` after each completion, fills empty pool slots immediately. |
| `agent_fox/engine/parallel.py` | Add `execute_one()` public method for streaming dispatch, `track_tasks()` for SIGINT cancellation, `max_parallelism` property. Keep `execute_batch()` for backward compatibility. |
| `agent_fox/engine/sync.py` | Guard `in_progress` nodes from cascade blocking — actively-running tasks should finish; their result is processed on completion. |
| `tests/unit/engine/test_orchestrator.py` | 5 new integration tests: dependency ordering in parallel mode, independent task dispatch, cascade blocking, streaming pool dispatch, pool bounded by max_parallelism. |
| `tests/unit/engine/test_parallel.py` | 4 new tests: `execute_one` success/failure, `track_tasks` + `cancel_all`, `max_parallelism` property. |
| `tests/unit/engine/test_sync.py` | 1 new test: `in_progress` tasks not cascade-blocked. |
| `tests/property/engine/test_sync_props.py` | 1 new property test: batch independence — no ready task depends on another ready task. |

## Tests

- 11 new tests added across unit and property test suites
- All 921 tests pass (0 regressions)
- Linter: clean
- Type checker: clean

## Verification

- All existing tests pass: ✅
- New tests pass: ✅
- Linter / formatter: ✅
- Type checker (mypy): ✅
- No regressions: ✅