### PR TITLE
fix(planner): support group-level cross-spec deps and alternative table format (fixes #67)

### DIFF
--- a/agent_fox/cli/plan.py
+++ b/agent_fox/cli/plan.py
@@ -63,7 +63,7 @@ def _build_plan(
         # Parse cross-spec deps from prd.md if present
         if spec.has_prd:
             prd_path = spec.path / "prd.md"
-            deps = parse_cross_deps(prd_path)
+            deps = parse_cross_deps(prd_path, spec_name=spec.name)
             cross_deps.extend(deps)
 
     # Filter cross-deps to only reference specs present in the discovered set.

--- a/agent_fox/engine/hot_load.py
+++ b/agent_fox/engine/hot_load.py
@@ -149,7 +149,7 @@ def _validate_and_parse_specs(
         dep_names = _parse_dep_specs_from_prd(prd_path)
 
         if not dep_names:
-            cross_deps = parse_cross_deps(prd_path)
+            cross_deps = parse_cross_deps(prd_path, spec_name=spec_info.name)
             dep_names = [d.to_spec for d in cross_deps]
 
         # 06-REQ-7.E1: Validate all dependencies exist

--- a/agent_fox/spec/parser.py
+++ b/agent_fox/spec/parser.py
@@ -25,8 +25,15 @@ _GROUP_PATTERN = re.compile(r"^- \[([ x\-])\] (\* )?(\d+)\. (.+)$")
 #   - [x] 2.3 Subtask title
 _SUBTASK_PATTERN = re.compile(r"^\s+- \[([ x\-])\] (\d+\.\d+) (.+)$")
 
-# Cross-spec dependency table header detection
+# Cross-spec dependency table header detection — standard format:
+#   | This Spec | Depends On | What It Uses |
 _DEP_TABLE_HEADER = re.compile(r"\|\s*This Spec\s*\|\s*Depends On\s*\|", re.IGNORECASE)
+
+# Alternative dependency table format with group-level granularity:
+#   | Spec | From Group | To Group | Relationship |
+_DEP_TABLE_HEADER_ALT = re.compile(
+    r"\|\s*Spec\s*\|\s*From Group\s*\|\s*To Group\s*\|", re.IGNORECASE
+)
 
 # Table separator row (e.g., |---|---|---|)
 _TABLE_SEP = re.compile(r"^\s*\|[\s\-|]+\|\s*$")
@@ -155,16 +162,59 @@ def parse_tasks(tasks_path: Path) -> list[TaskGroupDef]:
     return groups
 
 
-def parse_cross_deps(prd_path: Path) -> list[CrossSpecDep]:
-    """Parse cross-spec dependency table from a spec's prd.md.
+def _parse_table_rows(lines: list[str], start: int) -> list[list[str]]:
+    """Parse markdown table data rows starting after the header line.
 
-    Looks for a markdown table with columns matching
-    ``| This Spec | Depends On |``. Each data row yields a CrossSpecDep
-    with spec-level dependency (from_group=0 and to_group=0 as sentinels,
-    to be resolved by the builder to first/last group numbers).
+    Skips separator rows and stops at the first non-table line.
+    Returns a list of cell lists (one per data row).
+    """
+    rows: list[list[str]] = []
+    for line in lines[start:]:
+        if _TABLE_SEP.match(line):
+            continue
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            break
+        cells = [c.strip() for c in stripped.split("|")]
+        cells = [c for c in cells if c]
+        if cells:
+            rows.append(cells)
+    return rows
+
+
+def _safe_int(value: str, default: int = 0) -> int:
+    """Parse an integer from a string, returning *default* on failure."""
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return default
+
+
+def parse_cross_deps(
+    prd_path: Path,
+    spec_name: str | None = None,
+) -> list[CrossSpecDep]:
+    """Parse cross-spec dependency tables from a spec's prd.md.
+
+    Recognises two table formats:
+
+    **Standard format** (``| This Spec | Depends On |``):
+    Yields spec-level dependencies with sentinel group numbers (0/0),
+    resolved by the builder to the first/last groups.
+
+    **Alternative format** (``| Spec | From Group | To Group |``):
+    Yields group-level dependencies. Requires *spec_name* so the
+    parser knows which spec is declaring the dependency. The columns
+    map as follows:
+
+    - *Spec* — the dependency spec (``to_spec``)
+    - *From Group* — the group in the dependency spec (``to_group``)
+    - *To Group* — the group in this spec (``from_group``)
 
     Args:
         prd_path: Path to the spec's prd.md file.
+        spec_name: Name of the spec whose prd.md is being parsed.
+            Required for the alternative table format.
 
     Returns:
         List of CrossSpecDep declarations. Empty if no table found.
@@ -176,44 +226,50 @@ def parse_cross_deps(prd_path: Path) -> list[CrossSpecDep]:
     lines = text.splitlines()
 
     deps: list[CrossSpecDep] = []
-    in_table = False
-    header_found = False
 
-    for line in lines:
-        # Look for the dependency table header
-        if not header_found:
-            if _DEP_TABLE_HEADER.search(line):
-                header_found = True
-                in_table = True
-            continue
-
-        # Skip separator row
-        if in_table and _TABLE_SEP.match(line):
-            continue
-
-        # Parse data rows
-        if in_table:
-            # Stop at end of table (non-table line)
-            stripped = line.strip()
-            if not stripped.startswith("|"):
-                break
-
-            # Split cells by pipe
-            cells = [c.strip() for c in stripped.split("|")]
-            # Filter out empty strings from leading/trailing pipes
-            cells = [c for c in cells if c]
-
-            if len(cells) >= 2:
+    for i, line in enumerate(lines):
+        # --- Standard format: | This Spec | Depends On | ... ---
+        if _DEP_TABLE_HEADER.search(line):
+            for cells in _parse_table_rows(lines, i + 1):
+                if len(cells) < 2:
+                    continue
                 from_spec = cells[0].strip()
                 to_spec = cells[1].strip()
-                if from_spec and to_spec:
-                    deps.append(
-                        CrossSpecDep(
-                            from_spec=from_spec,
-                            from_group=0,  # sentinel: resolve to first group
-                            to_spec=to_spec,
-                            to_group=0,  # sentinel: resolve to last group
-                        )
+                if not from_spec or not to_spec:
+                    continue
+                deps.append(
+                    CrossSpecDep(
+                        from_spec=from_spec,
+                        from_group=0,  # sentinel: resolve to first group
+                        to_spec=to_spec,
+                        to_group=0,  # sentinel: resolve to last group
                     )
+                )
+
+        # --- Alternative format: | Spec | From Group | To Group | ... ---
+        elif _DEP_TABLE_HEADER_ALT.search(line):
+            if spec_name is None:
+                logger.warning(
+                    "Alternative dependency table found in '%s' but "
+                    "spec_name not provided; skipping.",
+                    prd_path,
+                )
+                continue
+            for cells in _parse_table_rows(lines, i + 1):
+                if len(cells) < 3:
+                    continue
+                dep_spec = cells[0].strip()
+                dep_group = _safe_int(cells[1].strip())
+                this_group = _safe_int(cells[2].strip())
+                if not dep_spec:
+                    continue
+                deps.append(
+                    CrossSpecDep(
+                        from_spec=spec_name,
+                        from_group=this_group,
+                        to_spec=dep_spec,
+                        to_group=dep_group,
+                    )
+                )
 
     return deps

--- a/tests/unit/graph/test_builder.py
+++ b/tests/unit/graph/test_builder.py
@@ -181,6 +181,75 @@ class TestBuildGraphCrossSpec:
         assert len(graph.nodes) == 4
 
 
+class TestBuildGraphCrossSpecGroupLevel:
+    """Group-level cross-spec edges connect specific groups, not first/last."""
+
+    def test_group_level_cross_spec_edge(self) -> None:
+        """Cross-spec dep with explicit groups creates correct edge."""
+        specs = [
+            _make_spec("01_alpha", 1),
+            _make_spec("02_beta", 2),
+        ]
+        groups = {
+            "01_alpha": [
+                _make_group(1, "Alpha 1"),
+                _make_group(2, "Alpha 2"),
+                _make_group(3, "Alpha 3"),
+            ],
+            "02_beta": [
+                _make_group(1, "Beta 1"),
+                _make_group(2, "Beta 2"),
+            ],
+        }
+        # Beta group 1 depends on Alpha group 2 (not Alpha's last group 3)
+        cross_deps = [
+            CrossSpecDep(
+                from_spec="02_beta", from_group=1,
+                to_spec="01_alpha", to_group=2,
+            ),
+        ]
+
+        graph = build_graph(specs, groups, cross_deps)
+
+        edge_pairs = [(e.source, e.target) for e in graph.edges]
+        assert ("01_alpha:2", "02_beta:1") in edge_pairs
+        # Should NOT have an edge from alpha:3 (the last group)
+        assert ("01_alpha:3", "02_beta:1") not in edge_pairs
+
+    def test_group_level_enables_earlier_scheduling(self) -> None:
+        """Group-level deps allow dependent tasks to start earlier."""
+        specs = [
+            _make_spec("01_alpha", 1),
+            _make_spec("02_beta", 2),
+        ]
+        groups = {
+            "01_alpha": [
+                _make_group(1, "Alpha 1"),
+                _make_group(2, "Alpha 2"),
+                _make_group(3, "Alpha 3"),
+                _make_group(4, "Alpha 4"),
+            ],
+            "02_beta": [
+                _make_group(1, "Beta 1"),
+                _make_group(2, "Beta 2"),
+            ],
+        }
+        # Beta:1 only needs Alpha:2, not all of Alpha
+        cross_deps = [
+            CrossSpecDep(
+                from_spec="02_beta", from_group=1,
+                to_spec="01_alpha", to_group=2,
+            ),
+        ]
+
+        graph = build_graph(specs, groups, cross_deps)
+
+        # Beta:1 should depend on Alpha:2, not Alpha:4
+        beta_1_preds = graph.predecessors("02_beta:1")
+        assert "01_alpha:2" in beta_1_preds
+        assert "01_alpha:4" not in beta_1_preds
+
+
 class TestDanglingCrossSpecRef:
     """TS-02-E5: Dangling cross-spec reference raises PlanError."""
 

--- a/tests/unit/spec/conftest.py
+++ b/tests/unit/spec/conftest.py
@@ -96,6 +96,27 @@ PRD_MD_NO_DEPS = """\
 This is the first specification with no dependencies.
 """
 
+PRD_MD_ALT_FORMAT = """\
+# PRD: CLI Banner Enhancement
+
+## Dependencies
+
+| Spec | From Group | To Group | Relationship |
+|------|-----------|----------|--------------|
+| 01_core_foundation | 4 | 1 | Imports CLI framework, theme system |
+| 03_session | 3 | 2 | Uses session context for banner data |
+"""
+
+PRD_MD_ALT_FORMAT_SINGLE = """\
+# PRD: Init Settings
+
+## Dependencies
+
+| Spec | From Group | To Group | Relationship |
+|------|-----------|----------|--------------|
+| 01_core_foundation | 3 | 1 | Extends the init command implemented in group 3 |
+"""
+
 
 # -- Fixture: specs directory with multiple specs, all with tasks.md --------
 
@@ -197,3 +218,35 @@ def tasks_md_empty(tmp_path: Path) -> Path:
     tasks_path = tmp_path / "tasks.md"
     tasks_path.write_text(TASKS_MD_EMPTY)
     return tasks_path
+
+
+@pytest.fixture
+def prd_md_standard_deps(tmp_path: Path) -> Path:
+    """Create a prd.md with standard dependency table format."""
+    prd_path = tmp_path / "prd.md"
+    prd_path.write_text(PRD_MD_WITH_DEPS)
+    return prd_path
+
+
+@pytest.fixture
+def prd_md_alt_format(tmp_path: Path) -> Path:
+    """Create a prd.md with alternative dependency table format."""
+    prd_path = tmp_path / "prd.md"
+    prd_path.write_text(PRD_MD_ALT_FORMAT)
+    return prd_path
+
+
+@pytest.fixture
+def prd_md_alt_format_single(tmp_path: Path) -> Path:
+    """Create a prd.md with alternative format, single dependency."""
+    prd_path = tmp_path / "prd.md"
+    prd_path.write_text(PRD_MD_ALT_FORMAT_SINGLE)
+    return prd_path
+
+
+@pytest.fixture
+def prd_md_no_deps(tmp_path: Path) -> Path:
+    """Create a prd.md with no dependency table."""
+    prd_path = tmp_path / "prd.md"
+    prd_path.write_text(PRD_MD_NO_DEPS)
+    return prd_path

--- a/tests/unit/spec/test_parser.py
+++ b/tests/unit/spec/test_parser.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from agent_fox.spec.parser import TaskGroupDef, parse_tasks
+from agent_fox.spec.parser import TaskGroupDef, parse_cross_deps, parse_tasks
 
 
 class TestParseTaskGroups:
@@ -150,3 +150,101 @@ class TestNonContiguousGroupNumbers:
         groups = parse_tasks(tasks_md_non_contiguous)
 
         assert len(groups) == 3
+
+
+class TestParseCrossDepStandardFormat:
+    """Parse cross-spec dependencies from standard table format."""
+
+    def test_parses_standard_dep(self, prd_md_standard_deps: Path) -> None:
+        """Standard format yields spec-level deps with sentinel groups."""
+        deps = parse_cross_deps(prd_md_standard_deps)
+
+        assert len(deps) == 1
+        assert deps[0].from_spec == "02_beta"
+        assert deps[0].to_spec == "01_alpha"
+
+    def test_standard_uses_sentinel_groups(
+        self, prd_md_standard_deps: Path
+    ) -> None:
+        """Standard format uses 0 sentinel for both group numbers."""
+        deps = parse_cross_deps(prd_md_standard_deps)
+
+        assert deps[0].from_group == 0
+        assert deps[0].to_group == 0
+
+    def test_no_deps_returns_empty(self, prd_md_no_deps: Path) -> None:
+        """prd.md without dependency table returns empty list."""
+        deps = parse_cross_deps(prd_md_no_deps)
+
+        assert deps == []
+
+
+class TestParseCrossDepAlternativeFormat:
+    """Parse cross-spec dependencies from alternative table format.
+
+    Alternative format: | Spec | From Group | To Group | Relationship |
+    Used by specs 14-17 for group-level dependency granularity.
+    """
+
+    def test_parses_alt_format_deps(self, prd_md_alt_format: Path) -> None:
+        """Alternative format yields correct number of deps."""
+        deps = parse_cross_deps(prd_md_alt_format, spec_name="14_cli_banner")
+
+        assert len(deps) == 2
+
+    def test_alt_format_first_dep_specs(
+        self, prd_md_alt_format: Path
+    ) -> None:
+        """First dep has correct from_spec and to_spec."""
+        deps = parse_cross_deps(prd_md_alt_format, spec_name="14_cli_banner")
+
+        assert deps[0].from_spec == "14_cli_banner"
+        assert deps[0].to_spec == "01_core_foundation"
+
+    def test_alt_format_first_dep_groups(
+        self, prd_md_alt_format: Path
+    ) -> None:
+        """First dep has correct group numbers (not sentinels)."""
+        deps = parse_cross_deps(prd_md_alt_format, spec_name="14_cli_banner")
+
+        # "From Group" 4 = group in dependency spec → to_group
+        assert deps[0].to_group == 4
+        # "To Group" 1 = group in this spec → from_group
+        assert deps[0].from_group == 1
+
+    def test_alt_format_second_dep(self, prd_md_alt_format: Path) -> None:
+        """Second dep has correct specs and groups."""
+        deps = parse_cross_deps(prd_md_alt_format, spec_name="14_cli_banner")
+
+        assert deps[1].from_spec == "14_cli_banner"
+        assert deps[1].to_spec == "03_session"
+        assert deps[1].to_group == 3
+        assert deps[1].from_group == 2
+
+    def test_alt_format_single_dep(
+        self, prd_md_alt_format_single: Path
+    ) -> None:
+        """Single-row alternative table parses correctly."""
+        deps = parse_cross_deps(
+            prd_md_alt_format_single, spec_name="17_init_settings"
+        )
+
+        assert len(deps) == 1
+        assert deps[0].from_spec == "17_init_settings"
+        assert deps[0].to_spec == "01_core_foundation"
+        assert deps[0].to_group == 3
+        assert deps[0].from_group == 1
+
+    def test_alt_format_without_spec_name_warns(
+        self, prd_md_alt_format: Path
+    ) -> None:
+        """Alternative format without spec_name logs warning and skips."""
+        deps = parse_cross_deps(prd_md_alt_format)
+
+        assert deps == []
+
+    def test_nonexistent_prd_returns_empty(self, tmp_path: Path) -> None:
+        """Non-existent prd.md returns empty list."""
+        deps = parse_cross_deps(tmp_path / "nonexistent.md", spec_name="foo")
+
+        assert deps == []


### PR DESCRIPTION
## Summary

Fixes the planning engine's naive cross-spec dependency handling. Two problems addressed:

1. **Alternative dependency table format silently ignored (correctness bug):** Specs 14–17 use `| Spec | From Group | To Group | Relationship |` headers which the parser never matched. These specs were scheduled with zero prerequisites.

2. **All cross-spec deps forced to spec-level granularity:** The parser always used sentinel group numbers (0/0), resolved to first→last groups. Now group-level declarations are parsed and preserved, enabling earlier scheduling of dependent tasks.

Closes #67

## Changes

| File | Change |
|------|--------|
| `agent_fox/spec/parser.py` | Add `_DEP_TABLE_HEADER_ALT` regex, `_parse_table_rows` + `_safe_int` helpers, `spec_name` param on `parse_cross_deps()` |
| `agent_fox/cli/plan.py` | Pass `spec.name` to `parse_cross_deps()` |
| `agent_fox/engine/hot_load.py` | Pass `spec_info.name` to `parse_cross_deps()` |
| `tests/unit/spec/conftest.py` | Add fixtures for alternative format prd.md files |
| `tests/unit/spec/test_parser.py` | Add `TestParseCrossDepStandardFormat` (3 tests) and `TestParseCrossDepAlternativeFormat` (7 tests) |
| `tests/unit/graph/test_builder.py` | Add `TestBuildGraphCrossSpecGroupLevel` (2 tests) |

## Tests

- 12 new tests covering both table formats and group-level edge construction
- All 933 tests pass (was 921 — 12 added, 0 regressions)
- Linter/formatter clean on all changed files

## Verification

- All existing tests pass: yes
- New tests pass: yes
- Linter / formatter: clean
- No regressions: confirmed