### PR TITLE
fix(knowledge): sync new facts to DuckDB before causal link storage (fixes #83)

### DIFF
--- a/agent_fox/engine/session_lifecycle.py
+++ b/agent_fox/engine/session_lifecycle.py
@@ -385,6 +385,9 @@ class NodeSessionRunner:
                     len(facts),
                     node_id,
                 )
+                # Sync new facts to DuckDB so causal link integrity
+                # checks can find them (fixes #83).
+                self._sync_facts_to_duckdb(facts)
                 # 13-REQ-2.1: Extract causal links if DuckDB available
                 self._extract_causal_links(facts, node_id)
         except Exception:
@@ -393,6 +396,39 @@ class NodeSessionRunner:
                 node_id,
                 exc_info=True,
             )
+
+    def _sync_facts_to_duckdb(self, facts: list) -> None:
+        """Insert facts into DuckDB memory_facts so causal links can reference them.
+
+        Best-effort: failures are logged and silently ignored.
+        Uses INSERT OR IGNORE for idempotency.
+        """
+        if self._knowledge_db is None:
+            return
+        conn = self._knowledge_db.connection
+        for fact in facts:
+            try:
+                conn.execute(
+                    "INSERT OR IGNORE INTO memory_facts "
+                    "(id, content, category, spec_name, session_id, "
+                    "commit_sha, confidence, created_at) "
+                    "VALUES (?::UUID, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)",
+                    [
+                        fact.id,
+                        fact.content,
+                        fact.category,
+                        fact.spec_name,
+                        getattr(fact, "session_id", None),
+                        getattr(fact, "commit_sha", None),
+                        fact.confidence,
+                    ],
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to sync fact %s to DuckDB",
+                    fact.id,
+                    exc_info=True,
+                )
 
     def _extract_causal_links(
         self,

--- a/tests/unit/engine/test_sync_facts_to_duckdb.py
+++ b/tests/unit/engine/test_sync_facts_to_duckdb.py
@@ -1,0 +1,109 @@
+"""Regression test: new facts are synced to DuckDB before causal link storage.
+
+Verifies the fix for issue #83 — causal links referencing newly extracted
+facts were skipped because the facts existed only in JSONL, not in DuckDB's
+memory_facts table.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_fox.core.config import AgentFoxConfig, KnowledgeConfig, ModelConfig
+from agent_fox.engine.session_lifecycle import NodeSessionRunner
+from agent_fox.knowledge.db import KnowledgeDB
+from agent_fox.memory.types import Fact
+
+
+def _make_fact(*, fact_id: str | None = None) -> Fact:
+    return Fact(
+        id=fact_id or str(uuid.uuid4()),
+        content="test fact",
+        category="decision",
+        spec_name="test_spec",
+        keywords=["test"],
+        confidence="high",
+        created_at="2025-01-01T00:00:00Z",
+        session_id="test/1",
+        commit_sha="abc123",
+    )
+
+
+@pytest.fixture
+def knowledge_db(tmp_path: str) -> KnowledgeDB:
+    config = KnowledgeConfig(store_path=":memory:")
+    db = KnowledgeDB(config)
+    db.open()
+    return db
+
+
+@pytest.fixture
+def lifecycle(knowledge_db: KnowledgeDB) -> NodeSessionRunner:
+    config = MagicMock(spec=AgentFoxConfig)
+    config.models = MagicMock(spec=ModelConfig)
+    return NodeSessionRunner(
+        node_id="test_spec:1",
+        config=config,
+        knowledge_db=knowledge_db,
+    )
+
+
+class TestSyncFactsToDuckDB:
+    """Verify _sync_facts_to_duckdb writes facts to memory_facts."""
+
+    def test_facts_written_to_duckdb(
+        self, lifecycle: NodeSessionRunner, knowledge_db: KnowledgeDB
+    ) -> None:
+        fact = _make_fact()
+        lifecycle._sync_facts_to_duckdb([fact])
+
+        rows = knowledge_db.connection.execute(
+            "SELECT id::VARCHAR FROM memory_facts WHERE id = ?::UUID",
+            [fact.id],
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == fact.id
+
+    def test_idempotent(
+        self, lifecycle: NodeSessionRunner, knowledge_db: KnowledgeDB
+    ) -> None:
+        fact = _make_fact()
+        lifecycle._sync_facts_to_duckdb([fact])
+        # Second call should not raise
+        lifecycle._sync_facts_to_duckdb([fact])
+
+        count = knowledge_db.connection.execute(
+            "SELECT COUNT(*) FROM memory_facts WHERE id = ?::UUID",
+            [fact.id],
+        ).fetchone()[0]
+        assert count == 1
+
+    def test_causal_links_succeed_after_sync(
+        self, lifecycle: NodeSessionRunner, knowledge_db: KnowledgeDB
+    ) -> None:
+        """End-to-end: after syncing, store_causal_links should find the facts."""
+        from agent_fox.knowledge.causal import store_causal_links
+
+        fact_a = _make_fact()
+        fact_b = _make_fact()
+        lifecycle._sync_facts_to_duckdb([fact_a, fact_b])
+
+        inserted = store_causal_links(
+            knowledge_db.connection,
+            [(fact_a.id, fact_b.id)],
+        )
+        assert inserted == 1
+
+    def test_no_knowledge_db_is_noop(self) -> None:
+        config = MagicMock(spec=AgentFoxConfig)
+        config.models = MagicMock(spec=ModelConfig)
+        lc = NodeSessionRunner(
+            node_id="test_spec:1",
+            config=config,
+            knowledge_db=None,
+        )
+        # Should not raise
+        lc._sync_facts_to_duckdb([_make_fact()])


### PR DESCRIPTION
## Summary

New facts extracted from a session were written to JSONL but not to DuckDB's `memory_facts` table. When `store_causal_links` checked referential integrity against DuckDB, it couldn't find the new facts and skipped all causal links referencing them with a warning. The fix adds a `_sync_facts_to_duckdb` step between fact extraction and causal link storage.

Closes #83

## Changes

| File | Change |
|------|--------|
| `agent_fox/engine/session_lifecycle.py` | Added `_sync_facts_to_duckdb` method; called before `_extract_causal_links` |
| `tests/unit/engine/test_sync_facts_to_duckdb.py` | 4 regression tests covering DuckDB sync, idempotency, causal link success, and no-DB noop |

## Tests

- `test_facts_written_to_duckdb`: verifies facts are inserted into DuckDB
- `test_idempotent`: verifies INSERT OR IGNORE prevents duplicates
- `test_causal_links_succeed_after_sync`: end-to-end verification that `store_causal_links` finds synced facts
- `test_no_knowledge_db_is_noop`: graceful noop when no knowledge DB

## Verification

- All existing tests pass: ✅ (1040 → 1044)
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*