### PR TITLE
fix(knowledge): sync all facts to DuckDB before storing causal links (fixes #83)

### DIFF
--- a/agent_fox/engine/session_lifecycle.py
+++ b/agent_fox/engine/session_lifecycle.py
@@ -385,9 +385,6 @@ class NodeSessionRunner:
                     len(facts),
                     node_id,
                 )
-                # Sync new facts to DuckDB so causal link integrity
-                # checks can find them (fixes #83).
-                self._sync_facts_to_duckdb(facts)
                 # 13-REQ-2.1: Extract causal links if DuckDB available
                 self._extract_causal_links(facts, node_id)
         except Exception:
@@ -478,6 +475,11 @@ class NodeSessionRunner:
             raw_text = getattr(response.content[0], "text", "[]")
             links = parse_causal_links(raw_text)
             if links:
+                # Sync ALL facts (prior + new) to DuckDB so the
+                # referential integrity check in store_causal_links
+                # can find every fact the LLM may have referenced.
+                all_facts = list(prior_facts) + list(new_facts)
+                self._sync_facts_to_duckdb(all_facts)
                 stored = store_causal_links(self._knowledge_db.connection, links)
                 logger.info(
                     "Stored %d causal links for session %s",

--- a/tests/unit/engine/test_sync_facts_to_duckdb.py
+++ b/tests/unit/engine/test_sync_facts_to_duckdb.py
@@ -107,3 +107,43 @@ class TestSyncFactsToDuckDB:
         )
         # Should not raise
         lc._sync_facts_to_duckdb([_make_fact()])
+
+    def test_prior_facts_synced_for_causal_links(
+        self, lifecycle: NodeSessionRunner, knowledge_db: KnowledgeDB
+    ) -> None:
+        """Regression: prior facts from JSONL must be synced to DuckDB so
+        causal links referencing them pass the referential integrity check.
+
+        This was the real root cause of issue #83 — the original fix only
+        synced new facts, but the LLM creates links between any facts
+        (including old ones that only exist in JSONL).
+        """
+        from agent_fox.knowledge.causal import store_causal_links
+
+        prior_fact = _make_fact()
+        new_fact = _make_fact()
+
+        # Simulate: prior_fact is only in JSONL (NOT in DuckDB)
+        # new_fact is synced via _sync_facts_to_duckdb
+        lifecycle._sync_facts_to_duckdb([new_fact])
+
+        # A causal link from prior -> new should FAIL because prior is missing
+        inserted = store_causal_links(
+            knowledge_db.connection,
+            [(prior_fact.id, new_fact.id)],
+        )
+        assert inserted == 0, (
+            "Causal link should fail when prior fact is not in DuckDB"
+        )
+
+        # Now sync BOTH facts (as the fix should do)
+        lifecycle._sync_facts_to_duckdb([prior_fact, new_fact])
+
+        # Now the link should succeed
+        inserted = store_causal_links(
+            knowledge_db.connection,
+            [(prior_fact.id, new_fact.id)],
+        )
+        assert inserted == 1, (
+            "Causal link should succeed after syncing prior facts"
+        )


### PR DESCRIPTION
## Summary

Fixes the recurring "Skipping causal link ... missing fact(s)" warnings by syncing ALL facts (prior + new) to DuckDB before storing causal links.

Closes #83

## Root Cause

The previous fix only synced newly extracted facts to DuckDB. But `_extract_causal_links` loads all prior facts from JSONL and passes them to the LLM, which can create causal links referencing old facts that only exist in JSONL — not in DuckDB's `memory_facts` table. Those links failed the referential integrity check.

## Changes

| File | Change |
|------|--------|
| `agent_fox/engine/session_lifecycle.py` | Moved `_sync_facts_to_duckdb` call into `_extract_causal_links`; now syncs all facts (prior + new) before storing links |
| `tests/unit/engine/test_sync_facts_to_duckdb.py` | Added regression test verifying prior facts must be synced for causal links to succeed |

## Tests

- `test_prior_facts_synced_for_causal_links`: verifies that links referencing prior-only facts fail without sync, succeed with sync

## Verification

- All engine/knowledge tests pass: ✅ (236 passed)
- New test passes: ✅
- Linter: ✅
- No regressions: ✅