### PR TITLE
fix(extraction): handle bracketed refs in LLM prose before JSON array (fixes #92)

### DIFF
--- a/agent_fox/memory/extraction.py
+++ b/agent_fox/memory/extraction.py
@@ -181,9 +181,7 @@ def _strip_markdown_fences(text: str) -> str:
     to locate a top-level JSON array bracket pair.
     """
     # 1. Strip ```json ... ``` or ``` ... ``` fences
-    fence_match = re.search(
-        r"```(?:json)?\s*\n?(.*?)```", text, re.DOTALL
-    )
+    fence_match = re.search(r"```(?:json)?\s*\n?(.*?)```", text, re.DOTALL)
     if fence_match:
         return fence_match.group(1).strip()
 
@@ -192,11 +190,26 @@ def _strip_markdown_fences(text: str) -> str:
     if stripped.startswith("["):
         return stripped
 
-    bracket_match = re.search(r"(\[.*\])", text, re.DOTALL)
-    if bracket_match:
-        return bracket_match.group(1).strip()
+    # 3. Find a valid JSON array using bracket-depth counting.
+    # The greedy regex (\[.*\]) fails when prose contains [bracketed]
+    # references (e.g. [uuid]) before the actual JSON array.
+    for match in re.finditer(r"\[", stripped):
+        start = match.start()
+        depth = 0
+        for i, ch in enumerate(stripped[start:], start=start):
+            if ch == "[":
+                depth += 1
+            elif ch == "]":
+                depth -= 1
+                if depth == 0:
+                    candidate = stripped[start : i + 1]
+                    try:
+                        json.loads(candidate)
+                        return candidate
+                    except (json.JSONDecodeError, ValueError):
+                        break
 
-    # 3. Give up — return original text so json.loads produces a clear error
+    # 4. Give up — return original text so json.loads produces a clear error
     return stripped
 
 

--- a/tests/unit/knowledge/test_extraction_causal.py
+++ b/tests/unit/knowledge/test_extraction_causal.py
@@ -117,6 +117,29 @@ class TestParseCausalLinksMarkdownFences:
         assert links[0] == ("x1", "x2")
 
 
+class TestParseCausalLinksWithEchoedRefs:
+    """parse_causal_links handles LLM responses that echo [uuid] refs in prose."""
+
+    def test_parses_links_after_echoed_uuid_references(self) -> None:
+        """JSON causal links are parsed when LLM echoes [uuid] refs in prose."""
+        response = (
+            "Looking at [aaa-111] and [bbb-222], I see a causal chain:\n\n"
+            '[{"cause_id": "aaa-111", "effect_id": "bbb-222"}]'
+        )
+        links = parse_causal_links(response)
+        assert len(links) == 1
+        assert links[0] == ("aaa-111", "bbb-222")
+
+    def test_parses_empty_array_after_echoed_refs(self) -> None:
+        """Empty JSON array is parsed when LLM echoes [uuid] refs in prose."""
+        response = (
+            "Reviewing [fact-1] and [fact-2], no causal relationship found.\n\n"
+            "[]"
+        )
+        links = parse_causal_links(response)
+        assert len(links) == 0
+
+
 class TestParseCausalLinksInvalidJSON:
     """TS-13-E3: Extraction returns completely invalid JSON.
 

--- a/tests/unit/memory/test_extraction.py
+++ b/tests/unit/memory/test_extraction.py
@@ -230,6 +230,30 @@ class TestStripMarkdownFences:
         result = _strip_markdown_fences(text)
         assert result == "not json at all"
 
+    def test_extracts_array_when_bracketed_refs_precede_json(self) -> None:
+        """Prose with [bracketed] references before the JSON array."""
+        text = (
+            'Looking at [uuid1] and [uuid2], I found:\n\n'
+            '[{"content": "a fact", "category": "gotcha", '
+            '"confidence": "high", "keywords": ["k"]}]'
+        )
+        result = _strip_markdown_fences(text)
+        parsed = __import__("json").loads(result)
+        assert isinstance(parsed, list)
+        assert parsed[0]["content"] == "a fact"
+
+    def test_extracts_array_from_prose_with_multiple_brackets(self) -> None:
+        """Multiple non-JSON brackets in prose before the real JSON array."""
+        text = (
+            "The fact [abc-123] caused [def-456] to change.\n"
+            "Here is the result:\n\n"
+            '[{"a": 1}]\n\n'
+            "Done!"
+        )
+        result = _strip_markdown_fences(text)
+        parsed = __import__("json").loads(result)
+        assert parsed == [{"a": 1}]
+
 
 class TestExtractionMarkdownFenced:
     """Extraction correctly handles LLM responses wrapped in markdown fences."""


### PR DESCRIPTION
## Summary

Replace the greedy regex `(\[.*\])` in `_strip_markdown_fences()` with a bracket-depth-counting approach that validates each candidate `[...]` block via `json.loads()`. The greedy regex failed when LLM responses contained `[bracketed]` references (e.g. echoed `[uuid]` fact IDs) in prose before the actual JSON array, causing both causal link parsing and fact extraction to silently return empty results.

Closes #92

## Changes

| File | Change |
|------|--------|
| `agent_fox/memory/extraction.py` | Replace greedy bracket regex with bracket-counting + JSON validation in `_strip_markdown_fences()` |
| `tests/unit/memory/test_extraction.py` | Add 2 regression tests for prose with `[bracketed]` references before JSON |
| `tests/unit/knowledge/test_extraction_causal.py` | Add 2 tests for `parse_causal_links` with echoed `[uuid]` references |

## Tests

- `test_extracts_array_when_bracketed_refs_precede_json`
- `test_extracts_array_from_prose_with_multiple_brackets`
- `test_parses_links_after_echoed_uuid_references`
- `test_parses_empty_array_after_echoed_refs`

## Verification

- All existing tests pass: :white_check_mark:
- New tests pass: :white_check_mark:
- Linter / formatter: :white_check_mark:
- No regressions: :white_check_mark: