### PR TITLE
fix(cli): replace Rich table with plain text in fix report (fixes #98)

### DIFF
--- a/agent_fox/fix/report.py
+++ b/agent_fox/fix/report.py
@@ -1,6 +1,6 @@
 """Fix report rendering.
 
-Renders the fix summary report to the console using Rich.
+Renders the fix summary report to the console as plain text.
 
 Requirements: 08-REQ-6.1, 08-REQ-6.2
 """
@@ -8,7 +8,6 @@ Requirements: 08-REQ-6.1, 08-REQ-6.2
 from __future__ import annotations
 
 from rich.console import Console
-from rich.table import Table
 
 from agent_fox.fix.loop import FixResult, TerminationReason  # noqa: F401
 
@@ -36,21 +35,13 @@ def render_fix_report(result: FixResult, console: Console) -> None:
         (str(result.termination_reason), "white"),
     )
 
-    # Summary table
-    table = Table(title="Fix Summary", show_header=True)
-    table.add_column("Metric", style="bold")
-    table.add_column("Value")
-
-    table.add_row("Passes completed", str(result.passes_completed))
-    table.add_row("Clusters resolved", str(result.clusters_resolved))
-    table.add_row("Clusters remaining", str(result.clusters_remaining))
-    table.add_row("Sessions consumed", str(result.sessions_consumed))
-    table.add_row(
-        "Termination reason",
-        f"[{reason_style}]{reason_label}[/{reason_style}]",
+    console.print(f"Passes completed: {result.passes_completed}")
+    console.print(f"Clusters resolved: {result.clusters_resolved}")
+    console.print(f"Clusters remaining: {result.clusters_remaining}")
+    console.print(f"Sessions consumed: {result.sessions_consumed}")
+    console.print(
+        f"Termination reason: [{reason_style}]{reason_label}[/{reason_style}]"
     )
-
-    console.print(table)
 
     # Remaining failures detail
     if result.remaining_failures:


### PR DESCRIPTION
## Summary

Replaces the Rich `Table` in `render_fix_report()` with plain `console.print()` lines, matching the simple text style used by the `status` command.

Closes #98

## Changes

| File | Change |
|------|--------|
| `agent_fox/fix/report.py` | Replace Rich Table with plain text `Label: value` output |

## Tests

- `tests/unit/fix/test_report.py`: 6 existing tests pass
- `tests/unit/fix/test_report_props.py`: 2 property tests pass

## Verification

- All existing tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*