### PR TITLE
feat(lint-spec): add archetype tag and checkbox state validation (fixes #120)

### DIFF
--- a/agent_fox/spec/fixer.py
+++ b/agent_fox/spec/fixer.py
@@ -16,13 +16,18 @@ from pathlib import Path
 
 from agent_fox.spec.discovery import SpecInfo
 from agent_fox.spec.parser import (
+    _ARCHETYPE_TAG,
     _DEP_TABLE_HEADER,
     _GROUP_PATTERN,
+    _KNOWN_ARCHETYPES,
     _SUBTASK_PATTERN,
     _TABLE_SEP,
 )
 from agent_fox.spec.validator import (
+    _CHECKBOX_LINE,
     _H2_HEADING,
+    _MALFORMED_ARCHETYPE_TAG,
+    _VALID_CHECKBOX_CHARS,
     Finding,
     _extract_req_ids_from_text,
     _extract_test_spec_ids,
@@ -70,6 +75,9 @@ FIXABLE_RULES = {
     "missing-definition-of-done",
     "missing-error-table",
     "missing-correctness-properties",
+    "invalid-archetype-tag",
+    "malformed-archetype-tag",
+    "invalid-checkbox-state",
 }
 
 # AI-specific fixable rules (only active when --ai flag is set)
@@ -643,6 +651,163 @@ def fix_missing_correctness_properties(
     ]
 
 
+def fix_invalid_archetype_tag(
+    spec_name: str,
+    tasks_path: Path,
+) -> list[FixResult]:
+    """Remove archetype tags that reference unknown archetype names.
+
+    Scans task group lines for [archetype: X] where X is not in
+    _KNOWN_ARCHETYPES, and removes the tag entirely (defaulting to coder).
+    """
+    if not tasks_path.is_file():
+        return []
+
+    text = tasks_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    results: list[FixResult] = []
+
+    for i, line in enumerate(lines):
+        if not re.match(r"^- \[.\]", line):
+            continue
+        match = _ARCHETYPE_TAG.search(line)
+        if match and match.group(1) not in _KNOWN_ARCHETYPES:
+            old_tag = match.group()
+            lines[i] = line.replace(old_tag, "").rstrip()
+            # Clean up double spaces left behind
+            lines[i] = re.sub(r"  +", " ", lines[i]).rstrip()
+            results.append(
+                FixResult(
+                    rule="invalid-archetype-tag",
+                    spec_name=spec_name,
+                    file=str(tasks_path),
+                    description=(
+                        f"Removed unknown archetype tag '{old_tag}' "
+                        f"from line {i + 1} (defaults to coder)"
+                    ),
+                )
+            )
+
+    if results:
+        tasks_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return results
+
+
+def fix_malformed_archetype_tag(
+    spec_name: str,
+    tasks_path: Path,
+) -> list[FixResult]:
+    """Normalize malformed archetype tags to [archetype: name] format.
+
+    Handles cases like [archtype: X], [Archetype: X], [archetype:X] (no space),
+    and duplicate tags (keeps first).
+    """
+    if not tasks_path.is_file():
+        return []
+
+    text = tasks_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    results: list[FixResult] = []
+
+    for i, line in enumerate(lines):
+        if not re.match(r"^- \[.\]", line):
+            continue
+
+        # Handle duplicate well-formed tags: keep first, remove rest
+        all_good = list(_ARCHETYPE_TAG.finditer(line))
+        if len(all_good) > 1:
+            # Remove all but the first tag
+            new_line = line
+            for m in reversed(all_good[1:]):
+                new_line = new_line[: m.start()] + new_line[m.end() :]
+            new_line = re.sub(r"  +", " ", new_line).rstrip()
+            lines[i] = new_line
+            results.append(
+                FixResult(
+                    rule="malformed-archetype-tag",
+                    spec_name=spec_name,
+                    file=str(tasks_path),
+                    description=(
+                        f"Removed duplicate archetype tags on line {i + 1}, "
+                        f"kept first"
+                    ),
+                )
+            )
+            continue
+
+        # Skip lines that already have a well-formed tag
+        if _ARCHETYPE_TAG.search(line):
+            continue
+
+        # Try to normalize malformed tags
+        bad_match = _MALFORMED_ARCHETYPE_TAG.search(line)
+        if bad_match:
+            bad_tag = bad_match.group()
+            # Extract the archetype name from the malformed tag
+            name_match = re.search(r"(\w+)\]$", bad_tag)
+            if name_match:
+                name = name_match.group(1).lower()
+                normalized = f"[archetype: {name}]"
+                lines[i] = line.replace(bad_tag, normalized)
+                results.append(
+                    FixResult(
+                        rule="malformed-archetype-tag",
+                        spec_name=spec_name,
+                        file=str(tasks_path),
+                        description=(
+                            f"Normalized '{bad_tag}' to '{normalized}' "
+                            f"on line {i + 1}"
+                        ),
+                    )
+                )
+
+    if results:
+        tasks_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return results
+
+
+def fix_invalid_checkbox_state(
+    spec_name: str,
+    tasks_path: Path,
+) -> list[FixResult]:
+    """Normalize invalid checkbox characters to [ ] (not started).
+
+    Scans task group and subtask lines for checkbox characters not in
+    {' ', 'x', '-', '~'} and replaces them with a space.
+    """
+    if not tasks_path.is_file():
+        return []
+
+    text = tasks_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    results: list[FixResult] = []
+
+    for i, line in enumerate(lines):
+        m = _CHECKBOX_LINE.match(line)
+        if m:
+            char = m.group(2)
+            if char not in _VALID_CHECKBOX_CHARS:
+                # Replace the invalid checkbox character with a space
+                start = m.start(2)
+                end = m.end(2)
+                lines[i] = line[:start] + " " + line[end:]
+                results.append(
+                    FixResult(
+                        rule="invalid-checkbox-state",
+                        spec_name=spec_name,
+                        file=str(tasks_path),
+                        description=(
+                            f"Normalized invalid checkbox '[{char}]' to '[ ]' "
+                            f"on line {i + 1}"
+                        ),
+                    )
+                )
+
+    if results:
+        tasks_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return results
+
+
 def apply_fixes(
     findings: list[Finding],
     discovered_specs: list[SpecInfo],
@@ -749,6 +914,24 @@ def apply_fixes(
                 design_path = spec.path / "design.md"
                 if design_path.is_file():
                     results = fix_missing_correctness_properties(spec_name, design_path)
+                    all_results.extend(results)
+
+            elif rule == "invalid-archetype-tag":
+                tasks_path = spec.path / "tasks.md"
+                if tasks_path.is_file():
+                    results = fix_invalid_archetype_tag(spec_name, tasks_path)
+                    all_results.extend(results)
+
+            elif rule == "malformed-archetype-tag":
+                tasks_path = spec.path / "tasks.md"
+                if tasks_path.is_file():
+                    results = fix_malformed_archetype_tag(spec_name, tasks_path)
+                    all_results.extend(results)
+
+            elif rule == "invalid-checkbox-state":
+                tasks_path = spec.path / "tasks.md"
+                if tasks_path.is_file():
+                    results = fix_invalid_checkbox_state(spec_name, tasks_path)
                     all_results.extend(results)
 
         except OSError as exc:

--- a/agent_fox/spec/parser.py
+++ b/agent_fox/spec/parser.py
@@ -18,12 +18,12 @@ logger = logging.getLogger(__name__)
 #   - [x] 2. Title          (completed)
 #   - [-] 3. Title          (in-progress)
 #   - [ ] * 4. Title        (optional)
-_GROUP_PATTERN = re.compile(r"^- \[([ x\-])\] (\* )?(\d+)\. (.+)$")
+_GROUP_PATTERN = re.compile(r"^- \[([ x\-~])\] (\* )?(\d+)\. (.+)$")
 
 # Subtask pattern (indented):
 #   - [ ] 1.1 Subtask title
 #   - [x] 2.3 Subtask title
-_SUBTASK_PATTERN = re.compile(r"^\s+- \[([ x\-])\] (\d+\.(?:\d+|V)) (.+)$")
+_SUBTASK_PATTERN = re.compile(r"^\s+- \[([ x\-~])\] (\d+\.(?:\d+|V)) (.+)$")
 
 # Cross-spec dependency table header detection — standard format:
 #   | This Spec | Depends On | What It Uses |

--- a/agent_fox/spec/validator.py
+++ b/agent_fox/spec/validator.py
@@ -14,8 +14,10 @@ from pathlib import Path
 
 from agent_fox.spec.discovery import SpecInfo  # noqa: F401
 from agent_fox.spec.parser import (
+    _ARCHETYPE_TAG,
     _DEP_TABLE_HEADER,
     _DEP_TABLE_HEADER_ALT,
+    _KNOWN_ARCHETYPES,
     TaskGroupDef,  # noqa: F401
     _parse_table_rows,
     _safe_int,
@@ -226,6 +228,137 @@ def check_missing_verification(
                     line=None,
                 )
             )
+    return findings
+
+
+# -- Regex patterns for archetype / checkbox validation ----------------------
+
+# Broader pattern to catch malformed archetype tags: matches things like
+# [archtype: X], [Archetype: X], [archetype X], [archetype:X], etc.
+_MALFORMED_ARCHETYPE_TAG = re.compile(
+    r"\[arch[e]?type[:\s]\s*\w+\]", re.IGNORECASE
+)
+
+# Valid checkbox characters in task group / subtask lines
+_VALID_CHECKBOX_CHARS = {" ", "x", "-", "~"}
+
+# Matches any checkbox-like pattern at the start of a task line
+_CHECKBOX_LINE = re.compile(r"^(\s*)- \[(.)\](\s+\*?\s*)(\d+)[\.\s]")
+
+
+def check_archetype_tags(
+    spec_name: str,
+    tasks_path: Path,
+) -> list[Finding]:
+    """Check archetype tags on task group titles for validity.
+
+    Rules:
+    - malformed-archetype-tag (error): tag syntax deviates from [archetype: X]
+    - invalid-archetype-tag (warning): archetype name not in registry
+    """
+    if not tasks_path.is_file():
+        return []
+
+    text = tasks_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    findings: list[Finding] = []
+
+    for i, line in enumerate(lines, 1):
+        # Only check top-level task group lines
+        if not re.match(r"^- \[.\]", line):
+            continue
+
+        # Check for well-formed archetype tag
+        good_match = _ARCHETYPE_TAG.search(line)
+        if good_match:
+            arch_name = good_match.group(1)
+            if arch_name not in _KNOWN_ARCHETYPES:
+                findings.append(
+                    Finding(
+                        spec_name=spec_name,
+                        file="tasks.md",
+                        rule="invalid-archetype-tag",
+                        severity=SEVERITY_WARNING,
+                        message=(
+                            f"Unknown archetype '{arch_name}' in task group title "
+                            f"(known: {', '.join(sorted(_KNOWN_ARCHETYPES))})"
+                        ),
+                        line=i,
+                    )
+                )
+            # Check for duplicate tags on same line
+            all_matches = _ARCHETYPE_TAG.findall(line)
+            if len(all_matches) > 1:
+                findings.append(
+                    Finding(
+                        spec_name=spec_name,
+                        file="tasks.md",
+                        rule="malformed-archetype-tag",
+                        severity=SEVERITY_ERROR,
+                        message=(
+                            f"Duplicate archetype tags on line {i}: "
+                            f"{', '.join(all_matches)}"
+                        ),
+                        line=i,
+                    )
+                )
+        else:
+            # Check for malformed variants
+            bad_match = _MALFORMED_ARCHETYPE_TAG.search(line)
+            if bad_match:
+                findings.append(
+                    Finding(
+                        spec_name=spec_name,
+                        file="tasks.md",
+                        rule="malformed-archetype-tag",
+                        severity=SEVERITY_ERROR,
+                        message=(
+                            f"Malformed archetype tag "
+                            f"'{bad_match.group()}' on line {i}; "
+                            f"expected format: [archetype: name]"
+                        ),
+                        line=i,
+                    )
+                )
+
+    return findings
+
+
+def check_checkbox_states(
+    spec_name: str,
+    tasks_path: Path,
+) -> list[Finding]:
+    """Check checkbox states in tasks.md for valid characters.
+
+    Rule: invalid-checkbox-state (error)
+    Valid characters: ' ' (space), 'x', '-', '~'
+    """
+    if not tasks_path.is_file():
+        return []
+
+    text = tasks_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    findings: list[Finding] = []
+
+    for i, line in enumerate(lines, 1):
+        m = _CHECKBOX_LINE.match(line)
+        if m:
+            char = m.group(2)
+            if char not in _VALID_CHECKBOX_CHARS:
+                findings.append(
+                    Finding(
+                        spec_name=spec_name,
+                        file="tasks.md",
+                        rule="invalid-checkbox-state",
+                        severity=SEVERITY_ERROR,
+                        message=(
+                            f"Invalid checkbox state '[{char}]' on line {i}; "
+                            f"valid states: [ ], [x], [-], [~]"
+                        ),
+                        line=i,
+                    )
+                )
+
     return findings
 
 
@@ -1379,6 +1512,12 @@ def validate_specs(
             groups = parsed_groups[spec.name]
             findings.extend(check_oversized_groups(spec.name, groups))
             findings.extend(check_missing_verification(spec.name, groups))
+
+        # 2b. Archetype tag and checkbox state checks
+        tasks_path = spec.path / "tasks.md"
+        if tasks_path.is_file():
+            findings.extend(check_archetype_tags(spec.name, tasks_path))
+            findings.extend(check_checkbox_states(spec.name, tasks_path))
 
         # 3. Acceptance criteria check
         if (spec.path / "requirements.md").is_file():

--- a/tests/unit/spec/test_fixer.py
+++ b/tests/unit/spec/test_fixer.py
@@ -12,6 +12,9 @@ from agent_fox.spec.discovery import SpecInfo
 from agent_fox.spec.fixer import (
     apply_fixes,
     fix_coarse_dependency,
+    fix_invalid_archetype_tag,
+    fix_invalid_checkbox_state,
+    fix_malformed_archetype_tag,
     fix_missing_verification,
 )
 from agent_fox.spec.validator import Finding
@@ -359,3 +362,127 @@ class TestApplyFixesNoOp:
         ]
         results = apply_fixes([], specs, tmp_path, {})
         assert len(results) == 0
+
+
+# -- Fix invalid archetype tag -----------------------------------------------
+
+
+class TestFixInvalidArchetypeTag:
+    """Verify fixer removes unknown archetype tags."""
+
+    def test_removes_unknown_archetype(self, tmp_path: Path) -> None:
+        tasks_path = _write_file(
+            tmp_path,
+            "tasks.md",
+            "## Tasks\n\n"
+            "- [ ] 1. Do stuff [archetype: hacker]\n"
+            "  - [ ] 1.1 Subtask\n",
+        )
+        results = fix_invalid_archetype_tag("test_spec", tasks_path)
+        assert len(results) == 1
+        assert results[0].rule == "invalid-archetype-tag"
+        content = tasks_path.read_text()
+        assert "[archetype: hacker]" not in content
+        assert "- [ ] 1. Do stuff" in content
+
+    def test_keeps_valid_archetype(self, tmp_path: Path) -> None:
+        tasks_path = _write_file(
+            tmp_path,
+            "tasks.md",
+            "## Tasks\n\n"
+            "- [ ] 1. Do stuff [archetype: coder]\n",
+        )
+        results = fix_invalid_archetype_tag("test_spec", tasks_path)
+        assert len(results) == 0
+        content = tasks_path.read_text()
+        assert "[archetype: coder]" in content
+
+
+# -- Fix malformed archetype tag ----------------------------------------------
+
+
+class TestFixMalformedArchetypeTag:
+    """Verify fixer normalizes malformed archetype tags."""
+
+    def test_normalizes_misspelled_tag(self, tmp_path: Path) -> None:
+        tasks_path = _write_file(
+            tmp_path,
+            "tasks.md",
+            "## Tasks\n\n"
+            "- [ ] 1. Do stuff [archtype: coder]\n",
+        )
+        results = fix_malformed_archetype_tag("test_spec", tasks_path)
+        assert len(results) == 1
+        assert results[0].rule == "malformed-archetype-tag"
+        content = tasks_path.read_text()
+        assert "[archetype: coder]" in content
+
+    def test_removes_duplicate_tags(self, tmp_path: Path) -> None:
+        tasks_path = _write_file(
+            tmp_path,
+            "tasks.md",
+            "## Tasks\n\n"
+            "- [ ] 1. Do stuff [archetype: coder] [archetype: skeptic]\n",
+        )
+        results = fix_malformed_archetype_tag("test_spec", tasks_path)
+        assert len(results) == 1
+        content = tasks_path.read_text()
+        assert content.count("[archetype:") == 1
+        assert "[archetype: coder]" in content
+
+    def test_no_change_for_valid_tag(self, tmp_path: Path) -> None:
+        tasks_path = _write_file(
+            tmp_path,
+            "tasks.md",
+            "## Tasks\n\n"
+            "- [ ] 1. Do stuff [archetype: skeptic]\n",
+        )
+        results = fix_malformed_archetype_tag("test_spec", tasks_path)
+        assert len(results) == 0
+
+
+# -- Fix invalid checkbox state -----------------------------------------------
+
+
+class TestFixInvalidCheckboxState:
+    """Verify fixer normalizes invalid checkbox characters to [ ]."""
+
+    def test_normalizes_invalid_char(self, tmp_path: Path) -> None:
+        tasks_path = _write_file(
+            tmp_path,
+            "tasks.md",
+            "## Tasks\n\n"
+            "- [?] 1. Bad state\n"
+            "  - [ ] 1.1 Subtask\n",
+        )
+        results = fix_invalid_checkbox_state("test_spec", tasks_path)
+        assert len(results) == 1
+        assert results[0].rule == "invalid-checkbox-state"
+        content = tasks_path.read_text()
+        assert "- [ ] 1. Bad state" in content
+        assert "[?]" not in content
+
+    def test_preserves_valid_states(self, tmp_path: Path) -> None:
+        tasks_path = _write_file(
+            tmp_path,
+            "tasks.md",
+            "## Tasks\n\n"
+            "- [ ] 1. Not started\n"
+            "- [x] 2. Done\n"
+            "- [-] 3. In progress\n"
+            "- [~] 4. Queued\n",
+        )
+        results = fix_invalid_checkbox_state("test_spec", tasks_path)
+        assert len(results) == 0
+
+    def test_normalizes_uppercase_x(self, tmp_path: Path) -> None:
+        tasks_path = _write_file(
+            tmp_path,
+            "tasks.md",
+            "## Tasks\n\n"
+            "- [X] 1. Uppercase X\n",
+        )
+        results = fix_invalid_checkbox_state("test_spec", tasks_path)
+        assert len(results) == 1
+        content = tasks_path.read_text()
+        assert "- [ ] 1. Uppercase X" in content

--- a/tests/unit/spec/test_validator.py
+++ b/tests/unit/spec/test_validator.py
@@ -14,7 +14,9 @@ from pathlib import Path
 from agent_fox.spec.parser import SubtaskDef, TaskGroupDef
 from agent_fox.spec.validator import (
     Finding,
+    check_archetype_tags,
     check_broken_dependencies,
+    check_checkbox_states,
     check_missing_acceptance_criteria,
     check_missing_files,
     check_missing_verification,
@@ -732,4 +734,127 @@ class TestValidDependenciesNoFindings:
         known_specs = {"01_core_foundation": [1, 2, 3]}
         findings = check_broken_dependencies("test_spec", fixture_path, known_specs)
 
+        assert len(findings) == 0
+
+
+# -- Archetype tag validation -------------------------------------------------
+
+
+class TestCheckArchetypeTags:
+    """Validate archetype tag detection on task group lines."""
+
+    def test_valid_archetype_no_findings(self, tmp_path: Path) -> None:
+        tasks = tmp_path / "tasks.md"
+        tasks.write_text(
+            "## Tasks\n\n"
+            "- [ ] 1. Write tests [archetype: coder]\n"
+            "  - [ ] 1.1 Subtask\n"
+        )
+        findings = check_archetype_tags("test_spec", tasks)
+        assert len(findings) == 0
+
+    def test_unknown_archetype_warning(self, tmp_path: Path) -> None:
+        tasks = tmp_path / "tasks.md"
+        tasks.write_text(
+            "## Tasks\n\n"
+            "- [ ] 1. Do stuff [archetype: hacker]\n"
+        )
+        findings = check_archetype_tags("test_spec", tasks)
+        assert len(findings) == 1
+        assert findings[0].rule == "invalid-archetype-tag"
+        assert findings[0].severity == "warning"
+        assert "hacker" in findings[0].message
+
+    def test_malformed_tag_detected(self, tmp_path: Path) -> None:
+        tasks = tmp_path / "tasks.md"
+        tasks.write_text(
+            "## Tasks\n\n"
+            "- [ ] 1. Do stuff [archtype: coder]\n"
+        )
+        findings = check_archetype_tags("test_spec", tasks)
+        assert len(findings) == 1
+        assert findings[0].rule == "malformed-archetype-tag"
+        assert findings[0].severity == "error"
+
+    def test_duplicate_tags_error(self, tmp_path: Path) -> None:
+        tasks = tmp_path / "tasks.md"
+        tasks.write_text(
+            "## Tasks\n\n"
+            "- [ ] 1. Do stuff [archetype: coder] [archetype: skeptic]\n"
+        )
+        findings = check_archetype_tags("test_spec", tasks)
+        assert len(findings) == 1
+        assert findings[0].rule == "malformed-archetype-tag"
+        assert findings[0].severity == "error"
+
+    def test_no_tag_no_finding(self, tmp_path: Path) -> None:
+        tasks = tmp_path / "tasks.md"
+        tasks.write_text(
+            "## Tasks\n\n"
+            "- [ ] 1. Write tests\n"
+            "  - [ ] 1.1 Subtask\n"
+        )
+        findings = check_archetype_tags("test_spec", tasks)
+        assert len(findings) == 0
+
+    def test_subtask_lines_ignored(self, tmp_path: Path) -> None:
+        """Archetype tags are only checked on group lines, not subtasks."""
+        tasks = tmp_path / "tasks.md"
+        tasks.write_text(
+            "## Tasks\n\n"
+            "- [ ] 1. Write tests\n"
+            "  - [ ] 1.1 Subtask with [archetype: hacker] in title\n"
+        )
+        findings = check_archetype_tags("test_spec", tasks)
+        assert len(findings) == 0
+
+
+# -- Checkbox state validation ------------------------------------------------
+
+
+class TestCheckCheckboxStates:
+    """Validate checkbox state detection on task lines."""
+
+    def test_valid_states_no_findings(self, tmp_path: Path) -> None:
+        tasks = tmp_path / "tasks.md"
+        tasks.write_text(
+            "## Tasks\n\n"
+            "- [ ] 1. Not started\n"
+            "- [x] 2. Completed\n"
+            "- [-] 3. In progress\n"
+            "- [~] 4. Queued\n"
+        )
+        findings = check_checkbox_states("test_spec", tasks)
+        assert len(findings) == 0
+
+    def test_invalid_state_detected(self, tmp_path: Path) -> None:
+        tasks = tmp_path / "tasks.md"
+        tasks.write_text(
+            "## Tasks\n\n"
+            "- [?] 1. Bad state\n"
+        )
+        findings = check_checkbox_states("test_spec", tasks)
+        assert len(findings) == 1
+        assert findings[0].rule == "invalid-checkbox-state"
+        assert findings[0].severity == "error"
+        assert "?" in findings[0].message
+
+    def test_multiple_invalid_states(self, tmp_path: Path) -> None:
+        tasks = tmp_path / "tasks.md"
+        tasks.write_text(
+            "## Tasks\n\n"
+            "- [!] 1. Bad one\n"
+            "- [X] 2. Wrong case\n"
+        )
+        findings = check_checkbox_states("test_spec", tasks)
+        assert len(findings) == 2
+
+    def test_optional_marker_valid(self, tmp_path: Path) -> None:
+        """The [ ]* optional marker should NOT trigger a finding."""
+        tasks = tmp_path / "tasks.md"
+        tasks.write_text(
+            "## Tasks\n\n"
+            "- [ ] * 1. Optional task\n"
+        )
+        findings = check_checkbox_states("test_spec", tasks)
         assert len(findings) == 0


### PR DESCRIPTION
## Summary

- Add three new lint-spec validation rules with `--fix` support: `invalid-archetype-tag`, `malformed-archetype-tag`, `invalid-checkbox-state`
- Extend parser to accept `~` (queued) as a valid checkbox state
- 17 new tests covering validation detection and auto-fix behavior

Closes #120

## Changes

| File | Change |
|------|--------|
| `agent_fox/spec/parser.py` | Extended regex patterns to accept `~` checkbox |
| `agent_fox/spec/validator.py` | Added `check_archetype_tags()` and `check_checkbox_states()` |
| `agent_fox/spec/fixer.py` | Added 3 fix functions, updated `FIXABLE_RULES` and `apply_fixes()` |
| `tests/unit/spec/test_validator.py` | 10 new tests |
| `tests/unit/spec/test_fixer.py` | 7 new tests |

## Test plan

- [x] All 73 validator/fixer tests pass
- [x] Full test suite: 1378 passed (4 pre-existing failures in knowledge/db unrelated)
- [x] No new linter warnings