### PR TITLE
fix: resolve 5 audit bugs — tools wiring, reset branch, JSON envelope, types (fixes #125)

### DIFF
--- a/agent_fox/cli/app.py
+++ b/agent_fox/cli/app.py
@@ -45,12 +45,12 @@ class BannerGroup(click.Group):
             super().invoke(ctx)
         except click.exceptions.Exit:
             raise
-        except click.ClickException:
+        except click.ClickException as exc:
             # In JSON mode, convert Click errors to JSON envelopes
             if ctx.obj and ctx.obj.get("json"):
                 from agent_fox.cli.json_io import emit_error
 
-                emit_error(str(ctx.invoked_subcommand or "unknown"))
+                emit_error(str(exc))
                 sys.exit(1)
             raise
         except AgentFoxError as exc:

--- a/agent_fox/cli/fix.py
+++ b/agent_fox/cli/fix.py
@@ -19,7 +19,7 @@ from rich.console import Console
 from agent_fox.cli import json_io
 from agent_fox.core.config import AgentFoxConfig
 from agent_fox.fix.checks import detect_checks
-from agent_fox.fix.fix import TerminationReason, run_fix_loop
+from agent_fox.fix.fix import FixSessionRunner, TerminationReason, run_fix_loop
 from agent_fox.fix.report import render_fix_report
 from agent_fox.fix.spec_gen import FixSpec
 from agent_fox.session.session import run_session
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 def _build_fix_session_runner(
     config: AgentFoxConfig, project_root: Path
-) -> TerminationReason | None:
+) -> FixSessionRunner:
     """Build a session runner callable for the fix loop.
 
     Returns an async callable that takes a FixSpec and runs a
@@ -60,7 +60,7 @@ def _build_fix_session_runner(
         model_entry = resolve_model(config.models.coding)
         return calculate_cost(outcome.input_tokens, outcome.output_tokens, model_entry)
 
-    return _run  # type: ignore[return-value]
+    return _run
 
 
 @click.command("fix")
@@ -142,16 +142,18 @@ def fix_cmd(ctx: click.Context, max_passes: int, dry_run: bool) -> None:
 
     # 23-REQ-5.3: emit JSONL in JSON mode
     if json_mode:
-        json_io.emit_line({
-            "event": "complete",
-            "summary": {
-                "passes_completed": result.passes_completed,
-                "clusters_resolved": result.clusters_resolved,
-                "clusters_remaining": result.clusters_remaining,
-                "sessions_consumed": result.sessions_consumed,
-                "termination_reason": str(result.termination_reason),
-            },
-        })
+        json_io.emit_line(
+            {
+                "event": "complete",
+                "summary": {
+                    "passes_completed": result.passes_completed,
+                    "clusters_resolved": result.clusters_resolved,
+                    "clusters_remaining": result.clusters_remaining,
+                    "sessions_consumed": result.sessions_consumed,
+                    "termination_reason": str(result.termination_reason),
+                },
+            }
+        )
     else:
         # Render the report
         render_fix_report(result, console)

--- a/agent_fox/engine/reset.py
+++ b/agent_fox/engine/reset.py
@@ -91,11 +91,13 @@ def _task_id_to_branch_name(task_id: str) -> str:
     """Convert a task ID to its feature branch name.
 
     Task ID format: "spec_name:group_number"
-    Branch name: "feature/spec_name-group_number"
+    Branch name: "feature/spec_name/group_number"
+
+    Must match the format used by ``workspace.py:create_worktree``.
     """
     parts = task_id.split(":")
     if len(parts) == 2:
-        return f"feature/{parts[0]}-{parts[1]}"
+        return f"feature/{parts[0]}/{parts[1]}"
     return f"feature/{task_id}"
 
 

--- a/agent_fox/session/backends/claude.py
+++ b/agent_fox/session/backends/claude.py
@@ -31,6 +31,7 @@ from agent_fox.session.backends.protocol import (
     ToolDefinition,
     ToolUseMessage,
 )
+from agent_fox.tools.server import FoxMCPServer
 
 logger = logging.getLogger(__name__)
 
@@ -94,12 +95,23 @@ class ClaudeBackend:
 
             can_use_tool = _can_use_tool_wrapper
 
+        # Build MCP server config for custom tools (29-REQ-6.2)
+        mcp_servers: dict[str, Any] = {}
+        if tools:
+            fox_server = FoxMCPServer()
+            mcp_servers["agent-fox-tools"] = {
+                "type": "sdk",
+                "name": "agent-fox-tools",
+                "instance": fox_server.mcp_server,
+            }
+
         options = ClaudeCodeOptions(
             cwd=cwd,
             model=model,
             system_prompt=system_prompt,
             permission_mode="bypassPermissions",
             can_use_tool=can_use_tool,
+            mcp_servers=mcp_servers,
         )
 
         try:

--- a/tests/integration/test_json_flag.py
+++ b/tests/integration/test_json_flag.py
@@ -53,14 +53,23 @@ def _make_standup_report(**overrides):
         "agent_commits": [],
         "human_commits": [],
         "queue": QueueSummary(
-            total=0, completed=0, in_progress=0, pending=0,
-            ready=0, blocked=0, failed=0, ready_task_ids=[],
+            total=0,
+            completed=0,
+            in_progress=0,
+            pending=0,
+            ready=0,
+            blocked=0,
+            failed=0,
+            ready_task_ids=[],
         ),
         "file_overlaps": [],
         "total_cost": 0.0,
         "agent": AgentActivity(
-            tasks_completed=0, sessions_run=0,
-            input_tokens=0, output_tokens=0, cost=0.0,
+            tasks_completed=0,
+            sessions_run=0,
+            input_tokens=0,
+            output_tokens=0,
+            cost=0.0,
             completed_task_ids=[],
         ),
         "cost_breakdown": [],
@@ -85,18 +94,24 @@ def tmp_project(tmp_path: Path) -> Path:
     subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
     subprocess.run(
         ["git", "config", "user.email", "test@test.com"],
-        cwd=repo, check=True, capture_output=True,
+        cwd=repo,
+        check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["git", "config", "user.name", "Test"],
-        cwd=repo, check=True, capture_output=True,
+        cwd=repo,
+        check=True,
+        capture_output=True,
     )
     readme = repo / "README.md"
     readme.write_text("# Test\n")
     subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
     subprocess.run(
         ["git", "commit", "-m", "initial"],
-        cwd=repo, check=True, capture_output=True,
+        cwd=repo,
+        check=True,
+        capture_output=True,
     )
 
     # Create .agent-fox structure
@@ -128,9 +143,7 @@ class TestGlobalFlagAccepted:
             mock_gen.return_value = _make_status_report()
             result = cli_runner.invoke(main, ["--json", "status"])
             # Exit code 2 means Click usage error
-            assert result.exit_code != 2, (
-                f"--json caused usage error: {result.output}"
-            )
+            assert result.exit_code != 2, f"--json caused usage error: {result.output}"
 
 
 # ---------------------------------------------------------------------------
@@ -198,9 +211,7 @@ class TestNoNonJsonStdout:
 class TestStatusJson:
     """TS-23-5: status --json emits a JSON object."""
 
-    def test_status_json_output(
-        self, cli_runner: CliRunner, tmp_project: Path
-    ) -> None:
+    def test_status_json_output(self, cli_runner: CliRunner, tmp_project: Path) -> None:
         """status with --json produces valid JSON."""
         with patch("agent_fox.cli.status.generate_status") as mock_gen:
             mock_gen.return_value = _make_status_report(
@@ -275,9 +286,7 @@ class TestLintSpecJson:
 class TestPlanJson:
     """TS-23-8: plan --json emits the execution plan as JSON."""
 
-    def test_plan_json_output(
-        self, cli_runner: CliRunner, tmp_project: Path
-    ) -> None:
+    def test_plan_json_output(self, cli_runner: CliRunner, tmp_project: Path) -> None:
         """plan with --json produces valid JSON."""
         # Create a minimal spec with tasks
         specs_dir = tmp_project / ".specs"
@@ -304,9 +313,7 @@ class TestPlanJson:
 class TestInitJson:
     """TS-23-12: init --json emits {"status": "ok"}."""
 
-    def test_init_json_output(
-        self, cli_runner: CliRunner, tmp_project: Path
-    ) -> None:
+    def test_init_json_output(self, cli_runner: CliRunner, tmp_project: Path) -> None:
         """init with --json produces {"status": "ok"}."""
         with patch("agent_fox.cli.init._ensure_develop_branch"):
             result = cli_runner.invoke(main, ["--json", "init"])
@@ -322,9 +329,7 @@ class TestInitJson:
 class TestResetJson:
     """TS-23-13: reset --json emits a JSON summary."""
 
-    def test_reset_json_output(
-        self, cli_runner: CliRunner, tmp_project: Path
-    ) -> None:
+    def test_reset_json_output(self, cli_runner: CliRunner, tmp_project: Path) -> None:
         """reset with --json produces valid JSON."""
         with patch("agent_fox.cli.reset.reset_all") as mock_reset:
             mock_reset.return_value = MagicMock(
@@ -347,9 +352,7 @@ class TestResetJson:
 class TestCodeJsonl:
     """TS-23-14: code --json emits JSONL."""
 
-    def test_code_jsonl_output(
-        self, cli_runner: CliRunner, tmp_project: Path
-    ) -> None:
+    def test_code_jsonl_output(self, cli_runner: CliRunner, tmp_project: Path) -> None:
         """code with --json produces JSONL (one JSON object per line)."""
         mock_state = MagicMock(
             node_states={"task1": "completed"},
@@ -373,10 +376,7 @@ class TestCodeJsonl:
                 plan_path.write_text('{"nodes": {}, "edges": [], "metadata": {}}')
 
                 result = cli_runner.invoke(main, ["--json", "code"])
-                lines = [
-                    ln for ln in result.output.strip().splitlines()
-                    if ln.strip()
-                ]
+                lines = [ln for ln in result.output.strip().splitlines() if ln.strip()]
                 for line in lines:
                     data = json.loads(line)
                     assert isinstance(data, dict)
@@ -390,9 +390,7 @@ class TestCodeJsonl:
 class TestFixJsonl:
     """TS-23-16: fix --json emits JSONL events."""
 
-    def test_fix_jsonl_output(
-        self, cli_runner: CliRunner, tmp_project: Path
-    ) -> None:
+    def test_fix_jsonl_output(self, cli_runner: CliRunner, tmp_project: Path) -> None:
         """fix with --json produces JSONL lines."""
         from agent_fox.fix.fix import TerminationReason
 
@@ -410,10 +408,7 @@ class TestFixJsonl:
             mock_run.return_value = mock_result
 
             result = cli_runner.invoke(main, ["--json", "fix"])
-            lines = [
-                ln for ln in result.output.strip().splitlines()
-                if ln.strip()
-            ]
+            lines = [ln for ln in result.output.strip().splitlines() if ln.strip()]
             for line in lines:
                 data = json.loads(line)
                 assert isinstance(data, dict)
@@ -515,9 +510,7 @@ class TestFormatRemovedLintSpec:
 class TestJsonWithVerbose:
     """TS-23-E1: --json --verbose produces JSON output."""
 
-    def test_json_with_verbose(
-        self, cli_runner: CliRunner, tmp_project: Path
-    ) -> None:
+    def test_json_with_verbose(self, cli_runner: CliRunner, tmp_project: Path) -> None:
         """--json --verbose still produces valid JSON on stdout."""
         with patch("agent_fox.cli.status.generate_status") as mock_gen:
             mock_gen.return_value = _make_status_report()
@@ -597,12 +590,18 @@ class TestStreamingInterrupted:
         self, cli_runner: CliRunner, tmp_project: Path
     ) -> None:
         """fix --json interrupted by KeyboardInterrupt emits status."""
+
+        def _close_coro_and_raise(coro, **kwargs):  # noqa: ARG001
+            """Close the coroutine to avoid 'never awaited' warning."""
+            coro.close()
+            raise KeyboardInterrupt
+
         with (
             patch("agent_fox.cli.fix.detect_checks") as mock_checks,
             patch("agent_fox.cli.fix.asyncio.run") as mock_run,
         ):
             mock_checks.return_value = [MagicMock()]
-            mock_run.side_effect = KeyboardInterrupt()
+            mock_run.side_effect = _close_coro_and_raise
 
             result = cli_runner.invoke(main, ["--json", "fix"])
             last_line = result.output.strip().splitlines()[-1]
@@ -642,5 +641,3 @@ class TestFormatUsageError:
         """status --format yaml exits with code 2."""
         result = cli_runner.invoke(main, ["status", "--format", "yaml"])
         assert result.exit_code == 2
-
-

--- a/tests/unit/cli/test_app.py
+++ b/tests/unit/cli/test_app.py
@@ -264,3 +264,21 @@ class TestTopLevelExceptionHandler:
             assert result.exit_code == 1
         finally:
             main.commands.pop("boom", None)
+
+    def test_click_exception_json_mode_emits_error_message(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """ClickException in JSON mode emits the error message."""
+        import json
+
+        cmd = _make_failing_subcommand(click.ClickException("bad input value"))
+        main.add_command(cmd, name="boom")
+        try:
+            result = cli_runner.invoke(main, ["--json", "boom"])
+            data = json.loads(result.output)
+            assert "error" in data
+            assert "bad input value" in data["error"]
+            # Must NOT contain the subcommand name as the error
+            assert data["error"] != "boom"
+        finally:
+            main.commands.pop("boom", None)

--- a/tests/unit/engine/test_reset.py
+++ b/tests/unit/engine/test_reset.py
@@ -14,7 +14,12 @@ from typing import Any
 import pytest
 
 from agent_fox.core.errors import AgentFoxError
-from agent_fox.engine.reset import reset_all, reset_task
+from agent_fox.engine.reset import (
+    _task_id_to_branch_name,
+    _task_id_to_worktree_path,
+    reset_all,
+    reset_task,
+)
 from agent_fox.engine.state import ExecutionState, StateManager
 
 # -- Helpers ---------------------------------------------------------------
@@ -80,6 +85,29 @@ def _write_state(
     )
     manager = StateManager(state_path)
     manager.save(state)
+
+
+# ---------------------------------------------------------------------------
+# Branch name and worktree path helpers
+# Regression: branch name must use slash separator to match workspace.py
+# ---------------------------------------------------------------------------
+
+
+class TestBranchAndWorktreeHelpers:
+    """Verify branch name and worktree path match workspace.py conventions."""
+
+    def test_branch_name_uses_slash_separator(self) -> None:
+        """Branch name must use slash (not hyphen) to match create_worktree."""
+        assert _task_id_to_branch_name("my_spec:3") == "feature/my_spec/3"
+
+    def test_branch_name_single_part_fallback(self) -> None:
+        """Single-part task ID uses feature/{id} format."""
+        assert _task_id_to_branch_name("standalone") == "feature/standalone"
+
+    def test_worktree_path_matches_branch_structure(self) -> None:
+        """Worktree path uses the same spec/group structure."""
+        wt = _task_id_to_worktree_path(Path("/wt"), "my_spec:3")
+        assert wt == Path("/wt/my_spec/3")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/session/backends/test_claude.py
+++ b/tests/unit/session/backends/test_claude.py
@@ -79,6 +79,48 @@ class TestExecuteConstructsOptions:
         assert hasattr(backend, "execute")
         assert callable(backend.execute)
 
+    @pytest.mark.asyncio
+    async def test_fox_tools_passed_as_mcp_server(self) -> None:
+        """When tools are provided, ClaudeCodeOptions includes an MCP server."""
+        from unittest.mock import patch
+
+        from agent_fox.session.backends.claude import ClaudeBackend
+        from agent_fox.session.backends.protocol import ToolDefinition
+
+        backend = ClaudeBackend()
+        tools = [
+            ToolDefinition(
+                name="fox_read",
+                description="Read file",
+                input_schema={"type": "object", "properties": {}},
+                handler=lambda **kw: "ok",
+            ),
+        ]
+
+        captured_options = {}
+
+        async def _fake_stream(*, prompt, options):
+            captured_options["opts"] = options
+            # yield nothing — just capture options
+            return
+            yield  # make it an async generator  # noqa: RET503
+
+        with patch.object(backend, "_stream_messages", _fake_stream):
+            async for _ in backend.execute(
+                "test",
+                system_prompt="sys",
+                model="claude-sonnet-4-6",
+                cwd="/tmp",
+                tools=tools,
+            ):
+                pass
+
+        opts = captured_options["opts"]
+        assert "agent-fox-tools" in opts.mcp_servers
+        srv_cfg = opts.mcp_servers["agent-fox-tools"]
+        assert srv_cfg["type"] == "sdk"
+        assert srv_cfg["instance"] is not None
+
 
 # ---------------------------------------------------------------------------
 # TS-26-8: session.py has no claude_code_sdk imports
@@ -94,8 +136,13 @@ class TestSessionNoSdkImports:
 
         session_path = os.path.join(
             os.path.dirname(__file__),
-            "..", "..", "..", "..",
-            "agent_fox", "session", "session.py",
+            "..",
+            "..",
+            "..",
+            "..",
+            "agent_fox",
+            "session",
+            "session.py",
         )
         session_path = os.path.normpath(session_path)
         with open(session_path, encoding="utf-8") as f:


### PR DESCRIPTION
## Summary

Fixes 5 of 6 bugs identified in the consolidated codebase audit (BUG-6 was already resolved).

Closes #125

## Changes

| File | Change |
|------|--------|
| `agent_fox/session/backends/claude.py` | Create `FoxMCPServer` and pass via `mcp_servers` to `ClaudeCodeOptions` so fox tools reach the backend (BUG-1) |
| `agent_fox/engine/reset.py` | Change branch name from `feature/{spec}-{group}` to `feature/{spec}/{group}` to match `workspace.py` (BUG-2) |
| `agent_fox/cli/app.py` | Emit `str(exc)` instead of subcommand name in ClickException JSON handler (BUG-3) |
| `agent_fox/cli/fix.py` | Fix return type annotation to `FixSessionRunner`, remove `type: ignore` (BUG-4) |
| `tests/integration/test_json_flag.py` | Close coroutine in mocked `asyncio.run` to prevent warning (BUG-5) |
| `tests/unit/engine/test_reset.py` | Add 3 regression tests for branch name format |
| `tests/unit/session/backends/test_claude.py` | Add test for MCP server tool forwarding |
| `tests/unit/cli/test_app.py` | Add test for JSON error envelope content |

## Tests

- `test_reset.py`: 3 new tests — branch name uses slash, single-part fallback, worktree path match
- `test_claude.py`: 1 new test — fox tools passed as MCP server config
- `test_app.py`: 1 new test — ClickException JSON envelope emits error message

## Verification

- All existing tests pass: ✅ (1553 passed, 5 new)
- Linter / formatter: ✅
- Warnings: 2 → 1 (remaining is non-deterministic GC timing from unrelated test)
- No regressions: ✅

---
*Auto-generated by `af-fix`.*