### PR TITLE
refactor: remove dead code (fixes #126)

### DIFF
--- a/agent_fox/cli/plan.py
+++ b/agent_fox/cli/plan.py
@@ -19,9 +19,8 @@ import click
 from agent_fox import __version__
 from agent_fox.core.errors import PlanError
 from agent_fox.graph.builder import build_graph
-from agent_fox.graph.resolver import apply_fast_mode
 from agent_fox.graph.persistence import load_plan, save_plan
-from agent_fox.graph.resolver import resolve_order
+from agent_fox.graph.resolver import apply_fast_mode, resolve_order
 from agent_fox.graph.types import NodeStatus, PlanMetadata, TaskGraph
 from agent_fox.spec.discovery import SpecInfo, discover_specs
 from agent_fox.spec.parser import CrossSpecDep, parse_cross_deps, parse_tasks
@@ -156,12 +155,10 @@ def _print_summary(graph: TaskGraph, specs: list[SpecInfo]) -> None:
 
     # Separate completed from remaining tasks
     completed = [
-        nid for nid in graph.order
-        if graph.nodes[nid].status == NodeStatus.COMPLETED
+        nid for nid in graph.order if graph.nodes[nid].status == NodeStatus.COMPLETED
     ]
     remaining = [
-        nid for nid in graph.order
-        if graph.nodes[nid].status != NodeStatus.COMPLETED
+        nid for nid in graph.order if graph.nodes[nid].status != NodeStatus.COMPLETED
     ]
 
     if completed:
@@ -181,7 +178,6 @@ def _print_summary(graph: TaskGraph, specs: list[SpecInfo]) -> None:
 @click.option("--fast", is_flag=True, help="Exclude optional tasks")
 @click.option("--spec", "filter_spec", default=None, help="Plan a single spec")
 @click.option("--reanalyze", is_flag=True, help="Discard cached plan")
-@click.option("--verify", is_flag=True, help="Verify dependency consistency")
 @click.option("--analyze", is_flag=True, help="Show parallelism analysis")
 @click.pass_context
 def plan_cmd(
@@ -189,15 +185,9 @@ def plan_cmd(
     fast: bool,
     filter_spec: str | None,
     reanalyze: bool,
-    verify: bool,
     analyze: bool,
 ) -> None:
     """Build an execution plan from specifications."""
-    # 02-REQ-7.5: --verify placeholder
-    if verify:
-        click.echo("Verify: not yet implemented.")
-        return
-
     # Determine project paths
     project_root = Path.cwd()
     specs_dir = project_root / ".specs"
@@ -270,15 +260,14 @@ def plan_cmd(
 
         from agent_fox.cli.json_io import emit
 
-        emit({
-            "nodes": {
-                nid: asdict(node)
-                for nid, node in graph.nodes.items()
-            },
-            "edges": [asdict(e) for e in graph.edges],
-            "order": graph.order,
-            "metadata": asdict(graph.metadata),
-        })
+        emit(
+            {
+                "nodes": {nid: asdict(node) for nid, node in graph.nodes.items()},
+                "edges": [asdict(e) for e in graph.edges],
+                "order": graph.order,
+                "metadata": asdict(graph.metadata),
+            }
+        )
         return
 
     _print_summary(graph, specs)

--- a/agent_fox/core/config.py
+++ b/agent_fox/core/config.py
@@ -244,7 +244,6 @@ class ArchetypesConfig(BaseModel):
     )
     models: dict[str, str] = Field(default_factory=dict)
     allowlists: dict[str, list[str]] = Field(default_factory=dict)
-    backends: dict[str, str] = Field(default_factory=dict)
 
     @field_validator("coder")
     @classmethod

--- a/agent_fox/engine/engine.py
+++ b/agent_fox/engine/engine.py
@@ -73,7 +73,9 @@ class SerialRunner:
     ) -> SessionRecord:
         """Execute a single session and return the outcome record."""
         runner = self._session_runner_factory(
-            node_id, archetype=archetype, instances=instances,
+            node_id,
+            archetype=archetype,
+            instances=instances,
         )
         return await invoke_runner(runner, node_id, attempt, previous_error)
 
@@ -262,6 +264,10 @@ class GraphSync:
             if all(self.node_states.get(d) == "completed" for d in deps):
                 ready.append(node_id)
         return sorted(ready)
+
+    def predecessors(self, node_id: str) -> list[str]:
+        """Return predecessor node IDs for *node_id*."""
+        return self._edges.get(node_id, [])
 
     def mark_completed(self, node_id: str) -> None:
         """Mark a task as completed."""
@@ -648,9 +654,7 @@ class Orchestrator:
                         state,
                         attempt_tracker,
                         error_tracker,
-                        first_dispatch,
                     )
-                    first_dispatch = False
                 else:
                     first_dispatch = await self._dispatch_serial(
                         ready,
@@ -775,7 +779,6 @@ class Orchestrator:
         state: ExecutionState,
         attempt_tracker: dict[str, int],
         error_tracker: dict[str, str | None],
-        first_dispatch: bool,
     ) -> None:
         """Dispatch ready tasks using a streaming pool.
 
@@ -979,7 +982,7 @@ class Orchestrator:
         """Get predecessor node IDs for a given node."""
         if self._graph_sync is None:
             return []
-        return self._graph_sync._edges.get(node_id, [])
+        return self._graph_sync.predecessors(node_id)
 
     def _run_sync_barrier_if_needed(self, state: ExecutionState) -> None:
         """Check and run sync barrier actions if triggered.

--- a/tests/integration/test_plan.py
+++ b/tests/integration/test_plan.py
@@ -240,9 +240,7 @@ class TestPlanCLIEndToEnd:
         second_spec = tmp_git_repo / ".specs" / "02_other"
         second_spec.mkdir(parents=True)
         (second_spec / "tasks.md").write_text(
-            "# Tasks\n\n"
-            "- [ ] 1. Add second feature\n"
-            "  - [ ] 1.1 Implement\n"
+            "# Tasks\n\n- [ ] 1. Add second feature\n  - [ ] 1.1 Implement\n"
         )
 
         first = cli_runner.invoke(main, ["plan"])
@@ -271,13 +269,12 @@ class TestPlanCLIEndToEnd:
 
         assert result.exit_code == 0
 
-    def test_plan_verify_placeholder(
+    def test_plan_verify_removed(
         self, cli_runner: CliRunner, tmp_git_repo: Path
     ) -> None:
-        """plan --verify prints placeholder message."""
+        """plan --verify is no longer a valid option (removed dead code)."""
         _setup_project(tmp_git_repo)
 
         result = cli_runner.invoke(main, ["plan", "--verify"])
 
-        assert result.exit_code == 0
-        assert "not yet implemented" in result.output.lower()
+        assert result.exit_code == 2


### PR DESCRIPTION
## Summary

Remove 4 directly fixable dead-code items identified in the consolidated audit report. 2 items (DEAD-1: archetype pipeline wiring, DEAD-3: CLI commands governance) are deferred as they need further exploration.

Closes #126

## Changes

| File | Change |
|------|--------|
| `agent_fox/cli/plan.py` | DEAD-2: Removed `--verify` flag and placeholder handler |
| `agent_fox/engine/engine.py` | DEAD-4: Added `GraphSync.predecessors()` public method, updated caller |
| `agent_fox/engine/engine.py` | DEAD-5: Removed unused `first_dispatch` param from `_dispatch_parallel` |
| `agent_fox/core/config.py` | DEAD-6: Removed unused `backends` field from `ArchetypesConfig` |
| `tests/integration/test_plan.py` | Updated test for removed `--verify` option |

## Tests

- All 1553 existing tests pass with no regressions
- Updated integration test verifies `--verify` is now rejected (exit code 2)

## Verification

- All existing tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*