### PR TITLE
fix(lint): resolve all auto-fixable ruff violations (fixes #128)

### DIFF
--- a/agent_fox/fix/__init__.py
+++ b/agent_fox/fix/__init__.py
@@ -4,4 +4,8 @@ Detects quality checks, collects failures, clusters them by root cause,
 generates fix specifications, and runs an iterative fix loop.
 """
 
-from agent_fox.fix.checks import CheckCategory, CheckDescriptor, FailureRecord  # noqa: F401
+from agent_fox.fix.checks import (  # noqa: F401
+    CheckCategory,
+    CheckDescriptor,
+    FailureRecord,
+)

--- a/agent_fox/reporting/standup.py
+++ b/agent_fox/reporting/standup.py
@@ -104,7 +104,9 @@ def partition_commits(
         return [], []
 
     if result.returncode != 0:
-        _git_activity_logger.warning("git log returned non-zero: %s", result.stderr.strip())
+        _git_activity_logger.warning(
+            "git log returned non-zero: %s", result.stderr.strip()
+        )
         return [], []
 
     all_commits = parse_git_log_output(result.stdout)

--- a/tests/unit/cli/test_knowledge_wiring.py
+++ b/tests/unit/cli/test_knowledge_wiring.py
@@ -14,10 +14,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from agent_fox.engine.session_lifecycle import NodeSessionRunner
 from agent_fox.core.config import AgentFoxConfig
-from agent_fox.memory.types import Fact
+from agent_fox.engine.session_lifecycle import NodeSessionRunner
 from agent_fox.knowledge.sink import SessionOutcome
+from agent_fox.memory.types import Fact
 from agent_fox.workspace.workspace import WorkspaceInfo
 
 
@@ -146,7 +146,7 @@ class TestFactExtractionAfterSession:
 
     @pytest.mark.asyncio
     async def test_extract_failure_does_not_block_session(self, tmp_path: Path) -> None:
-        """If extract_and_store_knowledge raises, the session still returns successfully."""
+        """Extract failure does not block the session."""
         workspace = _make_workspace(tmp_path)
         outcome = _make_outcome(status="completed")
 

--- a/tests/unit/fix/test_clusterer.py
+++ b/tests/unit/fix/test_clusterer.py
@@ -11,8 +11,8 @@ import json
 from unittest.mock import MagicMock, patch
 
 from agent_fox.core.config import AgentFoxConfig
-from agent_fox.fix.clusterer import cluster_failures
 from agent_fox.fix.checks import CheckCategory, CheckDescriptor
+from agent_fox.fix.clusterer import cluster_failures
 
 from .conftest import make_failure_record
 

--- a/tests/unit/fix/test_clusterer_props.py
+++ b/tests/unit/fix/test_clusterer_props.py
@@ -10,9 +10,8 @@ from __future__ import annotations
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from agent_fox.fix.checks import CheckCategory, CheckDescriptor, FailureRecord
 from agent_fox.fix.clusterer import _fallback_cluster
-from agent_fox.fix.checks import FailureRecord
-from agent_fox.fix.checks import CheckCategory, CheckDescriptor
 
 # Strategy: generate failure records with various check names
 check_name_st = st.sampled_from(["pytest", "ruff", "mypy", "npm test", "cargo test"])

--- a/tests/unit/fix/test_collector.py
+++ b/tests/unit/fix/test_collector.py
@@ -11,8 +11,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
-from agent_fox.fix.checks import run_checks
-from agent_fox.fix.checks import CheckDescriptor
+from agent_fox.fix.checks import CheckDescriptor, run_checks
 
 
 class TestCollectorCapturesFailures:

--- a/tests/unit/fix/test_collector_props.py
+++ b/tests/unit/fix/test_collector_props.py
@@ -13,8 +13,7 @@ from unittest.mock import patch
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from agent_fox.fix.checks import run_checks
-from agent_fox.fix.checks import CheckCategory, CheckDescriptor
+from agent_fox.fix.checks import CheckCategory, CheckDescriptor, run_checks
 
 # Strategy: generate a list of check descriptors with various exit codes
 check_names = st.sampled_from(["pytest", "ruff", "mypy", "cargo test", "npm test"])

--- a/tests/unit/fix/test_loop.py
+++ b/tests/unit/fix/test_loop.py
@@ -13,8 +13,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent_fox.core.config import AgentFoxConfig
-from agent_fox.fix.clusterer import FailureCluster
 from agent_fox.fix.checks import CheckCategory, CheckDescriptor
+from agent_fox.fix.clusterer import FailureCluster
 from agent_fox.fix.fix import TerminationReason, run_fix_loop
 
 from .conftest import make_failure_record

--- a/tests/unit/fix/test_loop_props.py
+++ b/tests/unit/fix/test_loop_props.py
@@ -14,9 +14,8 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from agent_fox.core.config import AgentFoxConfig
+from agent_fox.fix.checks import CheckCategory, CheckDescriptor, FailureRecord
 from agent_fox.fix.clusterer import FailureCluster
-from agent_fox.fix.checks import FailureRecord
-from agent_fox.fix.checks import CheckCategory, CheckDescriptor
 from agent_fox.fix.fix import run_fix_loop
 
 

--- a/tests/unit/knowledge/test_temporal.py
+++ b/tests/unit/knowledge/test_temporal.py
@@ -5,8 +5,6 @@ Requirements: 13-REQ-4.1, 13-REQ-4.2, 13-REQ-6.1, 13-REQ-6.2, 13-REQ-6.3
 
 from __future__ import annotations
 
-import duckdb
-
 from agent_fox.knowledge.query import Timeline, TimelineNode, temporal_query
 from tests.unit.knowledge.conftest import (
     FACT_AAA,

--- a/tests/unit/memory/test_render.py
+++ b/tests/unit/memory/test_render.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from agent_fox.memory.render import render_summary
 from agent_fox.memory.memory import write_facts
+from agent_fox.memory.render import render_summary
 from tests.unit.memory.conftest import make_fact
 
 

--- a/tests/unit/reporting/test_standup.py
+++ b/tests/unit/reporting/test_standup.py
@@ -11,13 +11,11 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from agent_fox.reporting.standup import (
-    is_agent_commit,
-    partition_commits,
-)
-from agent_fox.reporting.standup import (
     HumanCommit,
     _detect_overlaps,
     generate_standup,
+    is_agent_commit,
+    partition_commits,
 )
 
 from .conftest import (

--- a/tests/unit/spec/test_ai_validator.py
+++ b/tests/unit/spec/test_ai_validator.py
@@ -13,11 +13,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from agent_fox.spec.discovery import SpecInfo
 from agent_fox.spec.validator import (
     analyze_acceptance_criteria,
     run_ai_validation,
 )
-from agent_fox.spec.discovery import SpecInfo
 
 # -- Fixtures ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes all auto-fixable ruff violations across the codebase.

Closes #128

## Changes

| File | Change |
|------|--------|
| `agent_fox/fix/__init__.py` | Fix I001 import sorting |
| `agent_fox/reporting/standup.py` | Fix E501 line too long |
| `tests/unit/cli/test_knowledge_wiring.py` | Fix E501 + I001 |
| `tests/unit/fix/test_clusterer.py` | Fix I001 |
| `tests/unit/fix/test_clusterer_props.py` | Fix I001 |
| `tests/unit/fix/test_collector.py` | Fix I001 |
| `tests/unit/fix/test_collector_props.py` | Fix I001 |
| `tests/unit/fix/test_loop.py` | Fix I001 |
| `tests/unit/fix/test_loop_props.py` | Fix I001 |
| `tests/unit/knowledge/test_temporal.py` | Fix F401 unused import |
| `tests/unit/memory/test_render.py` | Fix I001 |
| `tests/unit/reporting/test_standup.py` | Fix I001 |
| `tests/unit/spec/test_ai_validator.py` | Fix I001 |

## Notes

Remaining `spec/validator.py` E402/F811 violations are deferred to SMELL-1 (extract `ai_validator.py`).

## Verification

- All 1583 tests pass
- No new ruff violations (only pre-existing validator.py E402/F811)