### PR TITLE
docs(specs): fix spec compliance drift (fixes #129)

### DIFF
--- a/.specs/01_core_foundation/design.md
+++ b/.specs/01_core_foundation/design.md
@@ -79,7 +79,7 @@ class ModelConfig(BaseModel):
     coding: str = "ADVANCED"
     coordinator: str = "STANDARD"
     memory_extraction: str = "SIMPLE"
-    embedding: str = "voyage-3"
+    embedding: str = "all-MiniLM-L6-v2"  # legacy field; actual config in KnowledgeConfig
 
 class HookConfig(BaseModel):
     pre_code: list[str] = Field(default_factory=list)

--- a/.specs/12_fox_ball/design.md
+++ b/.specs/12_fox_ball/design.md
@@ -16,7 +16,7 @@ flowchart TB
     CLI --> Oracle[Oracle<br/>RAG Pipeline]
 
     subgraph RAG Pipeline
-        Oracle --> EmbedQ[Embed Query<br/>voyage-3 API]
+        Oracle --> EmbedQ[Embed Query<br/>sentence-transformers]
         EmbedQ --> Search[Vector Search<br/>cosine similarity]
         Search --> Assemble[Assemble Context<br/>facts + provenance]
         Assemble --> Synthesize[Synthesize Answer<br/>STANDARD model]
@@ -48,7 +48,7 @@ flowchart TB
 ### Module Responsibilities
 
 1. `agent_fox/knowledge/embeddings.py` -- Generate embeddings using the
-   Anthropic voyage-3 API. Batch embedding for efficiency. Handle API
+   Anthropic sentence-transformers. Batch embedding for efficiency. Handle API
    failures gracefully (return None, let caller proceed without embedding).
 2. `agent_fox/knowledge/search.py` -- Vector similarity search over the
    `memory_embeddings` table. Cosine similarity ranking. Return top-k facts
@@ -72,37 +72,34 @@ flowchart TB
 ```python
 # agent_fox/knowledge/embeddings.py
 import logging
-from anthropic import Anthropic
+from sentence_transformers import SentenceTransformer
 from agent_fox.core.config import KnowledgeConfig
-from agent_fox.core.errors import KnowledgeStoreError
 
 logger = logging.getLogger("agent_fox.knowledge.embeddings")
 
 
 class EmbeddingGenerator:
-    """Generates vector embeddings using the Anthropic voyage-3 API.
+    """Generates vector embeddings using a local sentence-transformers model.
 
-    Handles API failures gracefully: returns None for individual texts
-    that fail to embed, allowing the caller to proceed without an
-    embedding.
+    The model is lazy-loaded on first use. Failures are handled
+    gracefully: returns None for individual texts that fail to embed,
+    allowing the caller to proceed without an embedding.
     """
 
     def __init__(self, config: KnowledgeConfig) -> None:
         self._config = config
-        self._client: Anthropic | None = None
+        self._model: SentenceTransformer | None = None
 
     @property
-    def client(self) -> Anthropic:
-        """Lazy-initialize the Anthropic client."""
-        if self._client is None:
-            self._client = Anthropic()
-        return self._client
+    def embedding_dimensions(self) -> int:
+        """Return the configured embedding dimensions."""
+        return self._config.embedding_dimensions
 
     def embed_text(self, text: str) -> list[float] | None:
         """Generate an embedding for a single text string.
 
-        Returns a list of floats (1024 dimensions for voyage-3) on
-        success, or None if the API call fails. Failures are logged
+        Returns a list of floats (384 dimensions for all-MiniLM-L6-v2)
+        on success, or None if embedding fails. Failures are logged
         as warnings, never raised.
         """
         ...
@@ -196,7 +193,7 @@ SELECT
     f.spec_name,
     f.session_id,
     f.commit_sha,
-    1 - array_cosine_distance(e.embedding, ?::FLOAT[1024]) AS similarity
+    1 - array_cosine_distance(e.embedding, ?::FLOAT[384]) AS similarity
 FROM memory_embeddings e
 JOIN memory_facts f ON e.id = f.id
 WHERE f.superseded_by IS NULL  -- exclude superseded facts
@@ -206,7 +203,7 @@ LIMIT ?;
 
 When `exclude_superseded=False`, the `WHERE` clause is omitted.
 
-The query parameter `?::FLOAT[1024]` receives the query embedding as a
+The query parameter `?::FLOAT[384]` receives the query embedding as a
 list of floats. The `1 - array_cosine_distance(...)` converts distance
 to similarity (higher = more similar).
 
@@ -534,7 +531,7 @@ class EmbeddedFact:
     content: str
     category: str
     spec_name: str
-    embedding: list[float]  # 1024-dim vector for voyage-3
+    embedding: list[float]  # 384-dim vector for all-MiniLM-L6-v2
 ```
 
 ### SearchResult
@@ -597,7 +594,7 @@ CREATE TABLE memory_facts (
 -- Vector embeddings for semantic search
 CREATE TABLE memory_embeddings (
     id        UUID PRIMARY KEY REFERENCES memory_facts(id),
-    embedding FLOAT[1024]
+    embedding FLOAT[384]
 );
 ```
 
@@ -676,7 +673,7 @@ sources and report them as `facts_skipped`.
 | Technology | Version | Purpose |
 |-----------|---------|---------|
 | duckdb | >=1.0 | Vector storage and similarity search |
-| anthropic | >=0.40 | Embedding generation (voyage-3) and answer synthesis |
+| sentence-transformers | >=2.0 | Local embedding generation (all-MiniLM-L6-v2) |
 | Python | 3.12+ | Runtime |
 | Click | 8.1+ | CLI command registration |
 | pytest | 8.0+ | Test framework |
@@ -707,7 +704,7 @@ A task group is complete when ALL of the following are true:
 - **All DuckDB tests use in-memory databases** (`duckdb.connect(":memory:")`)
   to avoid polluting the real knowledge store.
 - **The Anthropic API is always mocked** in tests. No network calls.
-  Mock responses provide realistic embedding vectors (1024 floats) and
+  Mock responses provide realistic embedding vectors (384 floats) and
   synthesis text.
 - **CLI tests use Click's CliRunner** with mocked oracle and knowledge store.
 - **Ingestion tests use `tmp_path`** for ADR fixtures and mocked

--- a/.specs/12_fox_ball/prd.md
+++ b/.specs/12_fox_ball/prd.md
@@ -27,8 +27,8 @@ The institutional knowledge exists but is locked inside the machine.
 
 - Dual-write memory facts to both JSONL (source of truth) and DuckDB
   (queryable index) on every fact extraction
-- Generate vector embeddings for each fact using the Anthropic voyage-3 API
-  and store them in the `memory_embeddings` table
+- Generate vector embeddings for each fact using a local sentence-transformers
+  model (all-MiniLM-L6-v2) and store them in the `memory_embeddings` table
 - Provide vector similarity search over the fact store, returning facts
   ranked by cosine similarity
 - Ingest additional knowledge sources (ADRs, git commits) as embedded facts
@@ -41,7 +41,7 @@ The institutional knowledge exists but is locked inside the machine.
 ## Non-Goals
 
 - Causal graph traversal and temporal queries -- that is spec 13 (Time Vision)
-- Local embedding models (sentence-transformers) -- future enhancement
+- Remote embedding APIs (e.g. Anthropic voyage-3) -- local model is preferred
 - Streaming answer generation -- single API call only
 - Migrating existing v1 JSONL data into DuckDB -- future `--rebuild-knowledge`
 - Automatic embedding backfill -- facts without embeddings are excluded from
@@ -51,8 +51,8 @@ The institutional knowledge exists but is locked inside the machine.
 
 ## Key Decisions
 
-- **Anthropic voyage-3 for embeddings** -- same API key as coding models, no
-  new vendor, 1024-dimensional vectors. Configured via `KnowledgeConfig`.
+- **Local sentence-transformers for embeddings** -- all-MiniLM-L6-v2, 384
+  dimensions, runs offline with no API cost. Configured via `KnowledgeConfig`.
 - **Dual-write, not replace** -- JSONL remains source of truth for fact
   content. DuckDB is a queryable index that can be rebuilt from JSONL if
   corrupted. JSONL deletion is data loss; DuckDB deletion is recoverable.

--- a/.specs/12_fox_ball/requirements.md
+++ b/.specs/12_fox_ball/requirements.md
@@ -14,7 +14,7 @@ tracking. Every requirement traces to PRD requirements REQ-150 through REQ-158.
 |------|-----------|
 | Dual-write | Writing a fact to both JSONL (source of truth) and DuckDB (queryable index) in a single operation |
 | Embedding | A fixed-length vector representation of text content, enabling semantic similarity comparison |
-| voyage-3 | Anthropic's embedding model producing 1024-dimensional vectors |
+| all-MiniLM-L6-v2 | Local sentence-transformers embedding model producing 384-dimensional vectors (runs offline, no API cost) |
 | Vector search | Finding records whose embedding vectors are most similar to a query vector, using cosine similarity |
 | Cosine similarity | A measure of similarity between two vectors, ranging from -1 (opposite) to 1 (identical) |
 | RAG | Retrieval-Augmented Generation -- embedding a query, retrieving relevant context, and synthesizing an answer |
@@ -61,8 +61,9 @@ embedding so that it can be found via semantic similarity search.
 #### Acceptance Criteria
 
 1. [12-REQ-2.1] WHEN a fact is written to DuckDB, THE system SHALL generate a
-   vector embedding using the configured embedding model (default: Anthropic
-   voyage-3, 1024 dimensions) and store it in the `memory_embeddings` table
+   vector embedding using the configured embedding model (default:
+   all-MiniLM-L6-v2 via sentence-transformers, 384 dimensions) and store it
+   in the `memory_embeddings` table
    alongside the fact.
 2. [12-REQ-2.2] THE system SHALL support batch embedding of multiple facts in
    a single API call for efficiency during bulk operations (e.g., ingestion

--- a/.specs/23_global_json_flag/requirements.md
+++ b/.specs/23_global_json_flag/requirements.md
@@ -145,3 +145,21 @@ input/output mode, enabling agent-to-agent and script-driven workflows.
 #### Edge Cases
 
 1. [23-REQ-8.E1] IF a user passes `--format` to a command that previously supported it, THEN THE system SHALL produce a Click usage error (standard Click behavior for unknown options).
+
+---
+
+## Amendment: Removed CLI Commands (2026-03-10)
+
+The following requirements reference CLI commands that have been removed from
+the CLI surface (see `docs/errata/unwired_cli_commands.md`):
+
+| Requirement | Command | Status |
+|-------------|---------|--------|
+| 23-REQ-3.5 | `patterns` | **Suspended** — command removed |
+| 23-REQ-3.6 | `compact` | **Suspended** — command removed |
+| 23-REQ-3.7 | `ingest` | **Suspended** — command removed (ingestion is now automatic) |
+| 23-REQ-5.2 | `ask` | **Suspended** — command removed |
+
+These requirements remain in the spec for traceability but are not enforced.
+They will be reinstated or formally superseded if/when the commands are
+re-introduced in a different form.

--- a/docs/errata/unwired_cli_commands.md
+++ b/docs/errata/unwired_cli_commands.md
@@ -22,3 +22,10 @@ has been restored and wired into the `agent-fox code` lifecycle as automatic
 background ingestion. ADRs and git commits are now ingested into DuckDB at
 three points: startup, sync barriers, and shutdown — without any CLI command
 required. The `ask`, `patterns`, and `compact` commands remain unwired.
+
+### Spec 23 Impact (2026-03-10)
+
+Spec 23 (Global `--json` Flag) requirements 23-REQ-3.5 (`patterns`),
+23-REQ-3.6 (`compact`), 23-REQ-3.7 (`ingest`), and 23-REQ-5.2 (`ask`)
+reference these removed commands. These requirements are suspended — see the
+amendment in `.specs/23_global_json_flag/requirements.md`.


### PR DESCRIPTION
## Summary

Fixes 3 of 4 spec compliance issues from audit. SPEC-1 depends on BUG-1 (issue #125).

Closes #129

## Changes

| File | Change |
|------|--------|
| `.specs/12_fox_ball/requirements.md` | Update embedding model: voyage-3 → all-MiniLM-L6-v2 |
| `.specs/12_fox_ball/prd.md` | Update goals, non-goals, key decisions for local embeddings |
| `.specs/12_fox_ball/design.md` | Update code examples, SQL schemas, dependency table |
| `.specs/01_core_foundation/design.md` | Update ModelConfig.embedding default |
| `.specs/23_global_json_flag/requirements.md` | Add amendment suspending reqs for removed commands |
| `docs/errata/unwired_cli_commands.md` | Cross-reference spec 23 impact |

## Item Status

| Item | Status | Notes |
|------|--------|-------|
| SPEC-1 | Deferred | Depends on BUG-1 (issue #125) |
| SPEC-2 | Already done | `--verify` removed in issue #126 |
| SPEC-3 | Fixed | Amendment added to spec 23 + errata updated |
| SPEC-4 | Fixed | Spec 12 updated to match implementation |

## Verification

- All 1583 tests pass
- No code changes (spec/docs only)