### PR TITLE
docs: comprehensive documentation refresh (fixes #145)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,20 +67,18 @@ with spec authoring, architecture decisions, code simplification, and more.
 
 ### Agent Archetypes
 
-By default every task runs as a **Coder** agent. You can enable specialized
-archetypes to add automated review and verification to the task graph:
+By default every task runs as a **Coder** agent. Specialized archetypes add
+automated review and verification at different stages of the pipeline:
 
-| Archetype | Purpose | Injection |
-|-----------|---------|-----------|
-| **Coder** | Implements code (always enabled) | default |
-| **Skeptic** | Reviews specs before coding begins | auto, before first coder group |
-| **Oracle** | Validates spec assumptions against codebase | auto, before first coder group |
-| **Verifier** | Checks code quality after coding | auto, after last coder group |
-| **Librarian** | Documentation tasks | manual assignment |
-| **Cartographer** | Architecture mapping | manual assignment |
-
-When both Skeptic and Oracle are enabled, they run in parallel before the first
-coder group.
+| Archetype | Purpose | Default |
+|-----------|---------|---------|
+| **Coder** | Implements code | always enabled |
+| **Skeptic** | Reviews specs before coding | enabled |
+| **Oracle** | Validates spec assumptions against codebase | disabled |
+| **Auditor** | Validates test code against test_spec contracts | disabled |
+| **Verifier** | Checks code quality after coding | enabled |
+| **Librarian** | Documentation tasks | disabled |
+| **Cartographer** | Architecture mapping | disabled |
 
 Skeptic and Verifier are enabled by default. Configure archetypes in your
 `config.toml`:
@@ -88,24 +86,10 @@ Skeptic and Verifier are enabled by default. Configure archetypes in your
 ```toml
 [archetypes]
 oracle = true         # enable oracle (disabled by default)
-
-[archetypes.instances]
-skeptic = 3           # run 3 independent reviewers, converge results
-
-[archetypes.skeptic_settings]
-block_threshold = 3   # block if > 3 majority-agreed critical findings
-
-[archetypes.oracle_settings]
-block_threshold = 5   # block if > 5 critical drift findings (omit for advisory only)
 ```
 
-You can also assign archetypes to specific task groups in `tasks.md`:
-
-```markdown
-- [ ] 5. Update documentation [archetype: librarian]
-```
-
-See the [ADR](docs/adr/agent-archetypes.md) for design rationale.
+See the [archetypes reference](docs/archetypes.md) for details on each
+archetype, and the [ADR](docs/adr/agent-archetypes.md) for design rationale.
 
 ### Adaptive Model Routing
 
@@ -118,41 +102,16 @@ The routing system learns from past executions: after enough history
 accumulates, a statistical model replaces the default heuristic rules and
 predictions improve over time.
 
-Configure routing behavior in `config.toml`:
-
-```toml
-[routing]
-retries_before_escalation = 1   # retries at same tier before escalating (0-3)
-training_threshold = 20         # min outcomes before training statistical model
-accuracy_threshold = 0.75       # min accuracy to prefer statistical over LLM
-retrain_interval = 10           # new outcomes between retraining cycles
-```
-
-Archetype model overrides act as tier ceilings — the system may start lower but
-never escalates above the configured tier:
-
-```toml
-[archetypes.models]
-coder = "STANDARD"    # coder tasks will never use ADVANCED
-```
-
-See the [ADR](docs/adr/adaptive-model-routing.md) for design rationale.
+See the [configuration reference](docs/configuration.md#routing) for routing
+options and the [ADR](docs/adr/adaptive-model-routing.md) for design rationale.
 
 ## Fox Tools (Token-Efficient File Tools)
 
 agent-fox includes four token-efficient file tools that reduce token usage
 and prevent silent corruption during file operations.
 
-### Enabling Fox Tools
-
-Add the following to your `config.toml`:
-
-```toml
-[tools]
-fox_tools = true
-```
-
-When enabled, the session runner registers four tools with the agent backend:
+Fox tools are enabled by default. When enabled, the session runner registers
+four tools with the agent backend:
 
 | Tool | Description |
 |------|-------------|
@@ -189,6 +148,15 @@ clear error message rather than running with degraded functionality.
 
 All knowledge-dependent features (memory facts, causal links, review findings,
 session outcomes, complexity assessments) require a working DuckDB connection.
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [CLI Reference](docs/cli-reference.md) | All commands, flags, and options |
+| [Configuration Reference](docs/configuration.md) | All `config.toml` sections and options |
+| [Archetypes](docs/archetypes.md) | Agent archetype details and configuration |
+| [Skills](docs/skills.md) | Claude Code skill reference |
 
 ## Development
 

--- a/docs/archetypes.md
+++ b/docs/archetypes.md
@@ -1,0 +1,288 @@
+# Agent Archetypes
+
+agent-fox uses specialized agent archetypes to assign distinct roles at
+different stages of the development pipeline. Each archetype has a focused
+purpose, a dedicated prompt template, and its own model tier and injection
+mode.
+
+## Overview
+
+| Archetype | Purpose | Injection | Default |
+|-----------|---------|-----------|---------|
+| **Coder** | Implement features, fix bugs, write tests | default | always enabled |
+| **Skeptic** | Review specs for issues before coding | auto, before first coder group | enabled |
+| **Oracle** | Validate spec assumptions against codebase | auto, before first coder group | disabled |
+| **Auditor** | Validate test code against test_spec contracts | auto, mid-execution | disabled |
+| **Verifier** | Check code quality after coding | auto, after last coder group | enabled |
+| **Librarian** | Documentation tasks | manual assignment | disabled |
+| **Cartographer** | Architecture mapping | manual assignment | disabled |
+
+When both Skeptic and Oracle are enabled, they run in parallel before the
+first coder group. If either produces blocking findings, coder sessions are
+not started.
+
+---
+
+## Coder
+
+**Purpose:** Implement code for one task group per session — features, bug
+fixes, tests, refactoring.
+
+- **Model tier:** ADVANCED (default)
+- **Injection:** Default — every task runs as a coder unless assigned another
+  archetype
+- **Always enabled:** The `coder` toggle cannot be disabled
+
+The coder receives specification documents, memory facts, and any findings
+from prior skeptic/oracle/verifier reviews. It follows a test-first workflow:
+group 1 writes failing tests from `test_spec.md`, subsequent groups implement
+code.
+
+**Outputs:** Implemented code, tests, conventional commits, session summary.
+
+---
+
+## Skeptic
+
+**Purpose:** Critically review specifications for completeness, consistency,
+and feasibility **before** implementation begins.
+
+- **Model tier:** STANDARD (default)
+- **Injection:** `auto_pre` — runs automatically before the first coder group
+- **Default:** Enabled
+- **Instances:** Configurable (1–5, default 1)
+- **Allowlist:** `ls`, `cat`, `git`, `wc`, `head`, `tail`
+
+The skeptic reads all specification documents and produces structured JSON
+findings categorized by severity (critical, major, minor, observation). It
+checks for:
+
+- Completeness gaps (missing requirements, untested paths)
+- Internal consistency (contradictions between artifacts)
+- Feasibility issues (unrealistic constraints, missing dependencies)
+- Testability (vague or unverifiable acceptance criteria)
+- Edge case coverage
+- Security concerns
+
+**Blocking:** If the number of majority-agreed critical findings exceeds
+`block_threshold` (default 3), coder sessions are blocked until the specs
+are revised.
+
+**Multi-instance convergence:** When `archetypes.instances.skeptic > 1`,
+multiple independent reviewers run in parallel. Their findings are converged
+using majority agreement — a finding must appear in a majority of reviews to
+count.
+
+### Configuration
+
+```toml
+[archetypes]
+skeptic = true
+
+[archetypes.instances]
+skeptic = 3           # run 3 independent reviewers
+
+[archetypes.skeptic_settings]
+block_threshold = 3   # block if > 3 majority-agreed critical findings
+```
+
+---
+
+## Oracle
+
+**Purpose:** Validate specification assumptions against the current codebase
+state — detect drift between what specs expect and what actually exists.
+
+- **Model tier:** STANDARD (default)
+- **Injection:** `auto_pre` — runs before the first coder group
+- **Default:** Disabled
+- **Allowlist:** `ls`, `cat`, `git`, `grep`, `find`, `head`, `tail`, `wc`
+
+The oracle reads specs and then explores the actual codebase to verify
+assumptions. It checks, in priority order:
+
+1. File and module existence
+2. Class and function existence
+3. Function signatures and parameter types
+4. API contracts and interfaces
+5. Behavioral assumptions
+
+**Blocking:** When `block_threshold` is set, blocks coder sessions if
+critical drift findings exceed the threshold. When omitted, the oracle is
+advisory only — findings are logged but do not block.
+
+### Configuration
+
+```toml
+[archetypes]
+oracle = true
+
+[archetypes.oracle_settings]
+block_threshold = 5   # block if > 5 critical drift findings (omit for advisory)
+
+[archetypes.models]
+oracle = "STANDARD"
+
+[archetypes.allowlists]
+oracle = ["ls", "cat", "git", "grep", "find", "head", "tail", "wc"]
+```
+
+See the [Oracle ADR](adr/oracle-archetype.md) for design rationale.
+
+---
+
+## Auditor
+
+**Purpose:** Validate test code written by coders against `test_spec.md`
+contracts — a test quality gate that ensures tests match their specifications.
+
+- **Model tier:** STANDARD (default)
+- **Injection:** `auto_mid` — runs during task group execution, after the
+  coder writes tests
+- **Default:** Disabled
+- **Instances:** Configurable (1–5, default 1)
+- **Allowlist:** `ls`, `cat`, `git`, `grep`, `find`, `head`, `tail`, `wc`, `uv`
+
+The auditor compares each test function against its corresponding
+`test_spec.md` entry and produces a structured JSON audit with per-entry
+verdicts:
+
+| Verdict | Meaning |
+|---------|---------|
+| **PASS** | Test fully covers the spec entry |
+| **WEAK** | Test exists but assertions are insufficient |
+| **MISSING** | No test found for the spec entry |
+| **MISALIGNED** | Test exists but tests something different |
+
+**Audit dimensions:**
+- Coverage (test function exists, happy path covered)
+- Assertion strength (meaningful assertions, specific values)
+- Precondition fidelity (setup matches spec entry exactly)
+- Edge case rigor (boundaries, error paths tested)
+- Independence (tests run in isolation)
+
+**Fail criteria:** The auditor fails (triggering a coder retry) if:
+- Any `MISSING` verdict
+- Any `MISALIGNED` verdict
+- Two or more `WEAK` verdicts
+
+The auditor-coder retry loop runs up to `max_retries` times (default 2).
+
+### Configuration
+
+```toml
+[archetypes]
+auditor = true
+
+[archetypes.auditor_config]
+min_ts_entries = 5    # minimum test_spec entries to trigger injection
+max_retries = 2       # maximum auditor-coder retry iterations
+
+[archetypes.instances]
+auditor = 1
+```
+
+---
+
+## Verifier
+
+**Purpose:** Verify that the coder's implementation matches specification
+requirements and quality standards — a post-coding quality gate.
+
+- **Model tier:** STANDARD (default)
+- **Injection:** `auto_post` — runs after the last coder group
+- **Default:** Enabled
+- **Instances:** Configurable (1–5, default 1)
+
+The verifier receives the specification documents, any prior skeptic/oracle
+findings, and the coder's implementation. It checks:
+
+- Requirements coverage (all acceptance criteria met)
+- Test execution (tests pass, no regressions)
+- Code quality (style, naming, patterns)
+- Spec conformance (implementation matches design)
+
+**Verdict:** PASS or FAIL. If the verifier fails, the coder is retried with
+the verifier's feedback.
+
+### Configuration
+
+```toml
+[archetypes]
+verifier = true
+
+[archetypes.instances]
+verifier = 1
+```
+
+---
+
+## Librarian
+
+**Purpose:** Create and maintain project documentation.
+
+- **Model tier:** STANDARD (default)
+- **Injection:** `manual` — must be explicitly assigned to a task group
+- **Default:** Disabled
+
+The librarian focuses on documentation quality: README updates, API docs,
+ADRs, setup guides, and inline docstrings. Assign it to specific task
+groups in `tasks.md`:
+
+```markdown
+- [ ] 5. Update documentation [archetype: librarian]
+```
+
+---
+
+## Cartographer
+
+**Purpose:** Map and document codebase architecture.
+
+- **Model tier:** STANDARD (default)
+- **Injection:** `manual` — must be explicitly assigned to a task group
+- **Default:** Disabled
+
+The cartographer produces architecture documentation, module diagrams, and
+component interaction maps. Assign it to specific task groups in `tasks.md`:
+
+```markdown
+- [ ] 6. Map architecture [archetype: cartographer]
+```
+
+---
+
+## Configuration Summary
+
+All archetype configuration lives under `[archetypes]` in `config.toml`.
+See the [configuration reference](configuration.md#archetypes) for the
+complete field listing.
+
+```toml
+# Enable/disable archetypes
+[archetypes]
+skeptic = true        # enabled by default
+verifier = true       # enabled by default
+oracle = false        # disabled by default
+auditor = false       # disabled by default
+librarian = false     # disabled by default
+cartographer = false  # disabled by default
+
+# Instance counts (for multi-instance convergence)
+[archetypes.instances]
+skeptic = 1
+verifier = 1
+auditor = 1
+
+# Per-archetype model tier overrides (act as ceilings)
+[archetypes.models]
+coder = "ADVANCED"
+oracle = "STANDARD"
+
+# Per-archetype command allowlists
+[archetypes.allowlists]
+oracle = ["ls", "cat", "git", "grep", "find", "head", "tail", "wc"]
+```
+
+See the [archetypes ADR](adr/agent-archetypes.md) for the overall design
+rationale.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -15,6 +15,7 @@ Complete reference for all `agent-fox` commands, options, and configuration.
 | `agent-fox reset` | Reset failed/blocked tasks for retry |
 | `agent-fox audit` | Query the structured audit log |
 | `agent-fox lint-spec` | Validate specification files |
+| `agent-fox serve-tools` | Launch fox tools MCP server |
 
 ## Global Options
 
@@ -133,7 +134,7 @@ agent-fox plan [OPTIONS]
 | `--fast` | flag | off | Exclude optional tasks |
 | `--spec NAME` | string | all | Plan a single spec |
 | `--reanalyze` | flag | off | Discard cached plan and rebuild |
-| `--verify` | flag | off | Verify dependency consistency (placeholder) |
+| `--analyze` | flag | off | Show parallelism analysis |
 
 Scans `.specs/` for specification folders, parses task groups, builds a
 dependency graph, resolves topological ordering, and persists the plan to
@@ -160,6 +161,7 @@ agent-fox code [OPTIONS]
 | `--no-hooks` | flag | off | Skip all hook scripts |
 | `--max-cost USD` | float | from config | Cost ceiling in USD |
 | `--max-sessions N` | int | from config | Session count limit |
+| `--debug` | flag | off | Enable debug audit trail (JSONL + DuckDB tool signals) |
 
 Runs the orchestrator, which dispatches coding sessions to a Claude agent for
 each ready task in the plan. Sessions execute in isolated git worktrees with
@@ -185,8 +187,12 @@ Requires `.agent-fox/plan.json` to exist (run `agent-fox plan` first).
 Show execution progress dashboard.
 
 ```
-agent-fox status
+agent-fox status [OPTIONS]
 ```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--model` | flag | off | Include project model and critical path analysis |
 
 Displays task counts (done, in-progress, pending, failed, blocked), token
 usage, estimated cost, problem tasks with reasons, per-archetype cost breakdown,
@@ -232,6 +238,8 @@ agent-fox fix [OPTIONS]
 |--------|------|---------|-------------|
 | `--max-passes N` | int | 3 | Maximum fix iterations (min 1) |
 | `--dry-run` | flag | off | Generate fix specs only, skip sessions |
+| `--auto` | flag | off | After repair, run iterative improvement passes |
+| `--improve-passes N` | int | 3 | Maximum improvement passes (requires `--auto`) |
 
 Runs quality checks (pytest, ruff, mypy, npm test, cargo test, etc.), clusters
 failures by root cause using AI, generates fix specifications, and runs coding
@@ -355,6 +363,7 @@ agent-fox lint-spec [OPTIONS]
 |--------|------|---------|-------------|
 | `--ai` | flag | off | Enable AI-powered semantic analysis |
 | `--fix` | flag | off | Auto-fix findings where possible |
+| `--all` | flag | off | Lint all specs, including fully-implemented ones |
 
 Use `agent-fox --json lint-spec` for structured JSON output.
 
@@ -380,152 +389,25 @@ the original criteria are left unchanged.
 
 ---
 
-## Configuration
+### serve-tools
 
-Configuration lives in `.agent-fox/config.toml`. All fields are optional;
-defaults are used for any absent field. Unknown keys are logged and ignored.
+Launch the fox tools MCP server on stdio.
 
-### `[orchestrator]`
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `parallel` | int | `1` | Max parallel sessions (1-8) |
-| `sync_interval` | int | `5` | Sessions between sync barriers (0 = disabled) |
-| `hot_load` | bool | `true` | Scan for new specs at sync barriers |
-| `max_retries` | int | `2` | Retries per failed task (0 = no retry) |
-| `session_timeout` | int | `30` | Session timeout in minutes (min 1) |
-| `inter_session_delay` | int | `3` | Seconds between sessions (0 = no delay) |
-| `max_cost` | float | none | Cost ceiling in USD |
-| `max_sessions` | int | none | Session count limit |
-| `audit_retention_runs` | int | `20` | Maximum number of runs to retain in the audit log (min 1) |
-
-### `[models]`
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `coding` | string | `"ADVANCED"` | Model tier or ID for coding sessions |
-| `coordinator` | string | `"STANDARD"` | Model tier or ID for coordination |
-| `memory_extraction` | string | `"SIMPLE"` | Model tier or ID for fact extraction |
-
-Model tiers: `SIMPLE`, `STANDARD`, `ADVANCED`. You can also specify a model ID
-directly (e.g., `claude-sonnet-4-6`).
-
-### `[hooks]`
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `pre_code` | list[string] | `[]` | Scripts to run before each session |
-| `post_code` | list[string] | `[]` | Scripts to run after each session |
-| `sync_barrier` | list[string] | `[]` | Scripts to run at sync barriers |
-| `timeout` | int | `300` | Hook timeout in seconds (min 1) |
-| `modes` | dict | `{}` | Per-script failure mode (`"abort"` or `"warn"`) |
-
-Default failure mode is `abort` (non-zero exit stops execution). Set a
-script's mode to `"warn"` to log a warning and continue.
-
-Hook environment variables: `AF_SPEC_NAME`, `AF_TASK_GROUP`, `AF_WORKSPACE`,
-`AF_BRANCH`.
-
-### `[security]`
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `bash_allowlist` | list[string] | none | Replace default command allowlist entirely |
-| `bash_allowlist_extend` | list[string] | `[]` | Add commands to the default allowlist |
-
-If both are set, `bash_allowlist` takes precedence (with a warning).
-
-### `[theme]`
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `playful` | bool | `true` | Use fox-themed messages |
-| `header` | string | `"bold #ff8c00"` | Rich style for headers |
-| `success` | string | `"bold green"` | Rich style for success |
-| `error` | string | `"bold red"` | Rich style for errors |
-| `warning` | string | `"bold yellow"` | Rich style for warnings |
-| `info` | string | `"#daa520"` | Rich style for info |
-| `tool` | string | `"bold #cd853f"` | Rich style for tool output |
-| `muted` | string | `"dim"` | Rich style for muted text |
-
-### `[platform]`
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `type` | string | `"none"` | Platform type: `"none"` or `"github"` |
-| `pr_granularity` | string | `"session"` | PR creation granularity |
-| `wait_for_ci` | bool | `false` | Wait for CI checks after PR creation |
-| `wait_for_review` | bool | `false` | Wait for PR review approval |
-| `auto_merge` | bool | `false` | Auto-merge approved PRs |
-| `ci_timeout` | int | `600` | CI wait timeout in seconds |
-| `labels` | list[string] | `[]` | Labels to apply to PRs |
-
-### `[archetypes]`
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `skeptic` | bool | `false` | Enable skeptic archetype (spec review) |
-| `oracle` | bool | `false` | Enable oracle archetype (spec drift detection) |
-| `verifier` | bool | `false` | Enable verifier archetype (post-code checks) |
-
-### `[archetypes.oracle_settings]`
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `block_threshold` | int | none | Block if critical drift findings exceed this count (advisory if omitted) |
-
-### `[archetypes.models]`
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `oracle` | string | `"STANDARD"` | Model tier ceiling for oracle sessions |
-
-### `[archetypes.allowlists]`
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `oracle` | list[string] | see below | Override oracle command allowlist (default: ls, cat, git, grep, find, head, tail, wc) |
-
-### `[pricing]`
-
-Configurable per-model pricing for cost calculations. If this section is absent,
-built-in defaults matching current Anthropic API rates are used.
-
-#### `[pricing.models.<model-id>]`
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `input_price_per_m` | float | varies | USD per million input tokens |
-| `output_price_per_m` | float | varies | USD per million output tokens |
-
-Default pricing:
-
-| Model | Input $/M | Output $/M |
-|-------|-----------|------------|
-| `claude-haiku-4-5` | `1.00` | `5.00` |
-| `claude-sonnet-4-6` | `3.00` | `15.00` |
-| `claude-opus-4-6` | `5.00` | `25.00` |
-
-Example:
-
-```toml
-[pricing.models.claude-haiku-4-5]
-input_price_per_m = 1.00
-output_price_per_m = 5.00
-
-[pricing.models.claude-sonnet-4-6]
-input_price_per_m = 3.00
-output_price_per_m = 15.00
+```
+agent-fox serve-tools [OPTIONS]
 ```
 
-Negative pricing values are clamped to zero with a warning.
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--allowed-dirs PATH` | path (multiple) | none | Restrict file operations to these directories |
 
-### `[knowledge]`
+Exposes the four fox tools (`fox_outline`, `fox_read`, `fox_edit`,
+`fox_search`) over the standard MCP stdio transport. Path sandboxing via
+`--allowed-dirs` restricts file operations to the specified directories and
+their descendants.
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `store_path` | string | `".agent-fox/knowledge.duckdb"` | DuckDB database path |
-| `embedding_model` | string | `"all-MiniLM-L6-v2"` | Embedding model name (sentence-transformers) |
-| `embedding_dimensions` | int | `384` | Embedding vector dimensions |
-| `ask_top_k` | int | `20` | Default top-k for `ask` queries (min 1) |
-| `ask_synthesis_model` | string | `"STANDARD"` | Model for answer synthesis |
+---
+
+## Configuration
+
+For the complete configuration reference, see [configuration.md](configuration.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,274 @@
+# Configuration Reference
+
+Configuration lives in `.agent-fox/config.toml`. All fields are optional;
+defaults are used for any absent field. Unknown top-level keys are logged and
+ignored.
+
+Run `agent-fox init` to generate a config file with all options documented as
+commented-out entries. Re-running `init` merges new options into an existing
+config non-destructively.
+
+---
+
+## `[orchestrator]`
+
+Controls the execution engine.
+
+| Key | Type | Default | Range | Description |
+|-----|------|---------|-------|-------------|
+| `parallel` | int | `1` | 1–8 | Max parallel sessions |
+| `sync_interval` | int | `5` | 0+ | Sessions between sync barriers (0 = disabled) |
+| `hot_load` | bool | `true` | | Scan for new specs at sync barriers |
+| `max_retries` | int | `2` | 0+ | Retries per failed task |
+| `session_timeout` | int | `30` | 1+ | Session timeout in minutes |
+| `inter_session_delay` | int | `3` | 0+ | Seconds between sessions |
+| `max_cost` | float | none | | Cost ceiling in USD |
+| `max_sessions` | int | none | | Session count limit |
+| `audit_retention_runs` | int | `20` | 1+ | Maximum runs to retain in the audit log |
+
+---
+
+## `[routing]`
+
+Controls adaptive model routing — automatic selection of the cheapest model
+tier that can handle each task, with escalation on failure.
+
+| Key | Type | Default | Range | Description |
+|-----|------|---------|-------|-------------|
+| `retries_before_escalation` | int | `1` | 0–3 | Retries at same tier before escalating |
+| `training_threshold` | int | `20` | 5–1000 | Min outcomes before training statistical model |
+| `accuracy_threshold` | float | `0.75` | 0.5–1.0 | Min accuracy to prefer statistical over heuristic |
+| `retrain_interval` | int | `10` | 5–100 | New outcomes between retraining cycles |
+
+See the [ADR](adr/adaptive-model-routing.md) for design rationale.
+
+---
+
+## `[models]`
+
+Model tier assignment for different roles.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `coding` | string | `"ADVANCED"` | Model tier for coding sessions |
+| `coordinator` | string | `"STANDARD"` | Model tier for coordination |
+| `memory_extraction` | string | `"SIMPLE"` | Model tier for fact extraction |
+
+Model tiers: `SIMPLE`, `STANDARD`, `ADVANCED`. You can also specify a model ID
+directly (e.g., `claude-sonnet-4-6`).
+
+---
+
+## `[hooks]`
+
+Lifecycle hooks executed at various stages.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `pre_code` | list[string] | `[]` | Scripts to run before each session |
+| `post_code` | list[string] | `[]` | Scripts to run after each session |
+| `sync_barrier` | list[string] | `[]` | Scripts to run at sync barriers |
+| `timeout` | int | `300` | Hook timeout in seconds (min 1) |
+| `modes` | dict | `{}` | Per-script failure mode (`"abort"` or `"warn"`) |
+
+Default failure mode is `abort` (non-zero exit stops execution). Set a
+script's mode to `"warn"` to log a warning and continue.
+
+Hook environment variables: `AF_SPEC_NAME`, `AF_TASK_GROUP`, `AF_WORKSPACE`,
+`AF_BRANCH`.
+
+---
+
+## `[security]`
+
+Bash command security controls.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `bash_allowlist` | list[string] | none | Replace default command allowlist entirely |
+| `bash_allowlist_extend` | list[string] | `[]` | Add commands to the default allowlist |
+
+If both are set, `bash_allowlist` takes precedence (with a warning).
+
+---
+
+## `[theme]`
+
+UI theme and output styling using [Rich](https://rich.readthedocs.io/) style
+strings.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `playful` | bool | `true` | Use fox-themed messages |
+| `header` | string | `"bold #ff8c00"` | Rich style for headers |
+| `success` | string | `"bold green"` | Rich style for success |
+| `error` | string | `"bold red"` | Rich style for errors |
+| `warning` | string | `"bold yellow"` | Rich style for warnings |
+| `info` | string | `"#daa520"` | Rich style for info |
+| `tool` | string | `"bold #cd853f"` | Rich style for tool output |
+| `muted` | string | `"dim"` | Rich style for muted text |
+
+---
+
+## `[platform]`
+
+GitHub platform integration.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `type` | string | `"none"` | Platform type: `"none"` or `"github"` |
+| `auto_merge` | bool | `false` | Auto-merge approved PRs |
+
+---
+
+## `[knowledge]`
+
+Knowledge store and fact selection.
+
+| Key | Type | Default | Range | Description |
+|-----|------|---------|-------|-------------|
+| `store_path` | string | `".agent-fox/knowledge.duckdb"` | | DuckDB database path |
+| `embedding_model` | string | `"all-MiniLM-L6-v2"` | | Embedding model name (sentence-transformers) |
+| `embedding_dimensions` | int | `384` | | Embedding vector dimensions |
+| `ask_top_k` | int | `20` | 1+ | Default top-k for knowledge queries |
+| `ask_synthesis_model` | string | `"STANDARD"` | | Model for answer synthesis |
+| `confidence_threshold` | float | `0.5` | 0.0–1.0 | Minimum confidence for fact inclusion in session context |
+| `fact_cache_enabled` | bool | `true` | | Pre-compute fact rankings at plan time |
+
+---
+
+## `[archetypes]`
+
+Enable or disable agent archetypes. See the [archetypes reference](archetypes.md)
+for details on each archetype's role and workflow.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `coder` | bool | `true` | Enable coder archetype (cannot be disabled) |
+| `skeptic` | bool | `true` | Enable skeptic archetype (spec review) |
+| `verifier` | bool | `true` | Enable verifier archetype (post-code checks) |
+| `oracle` | bool | `false` | Enable oracle archetype (spec drift detection) |
+| `librarian` | bool | `false` | Enable librarian archetype (documentation) |
+| `cartographer` | bool | `false` | Enable cartographer archetype (architecture mapping) |
+| `auditor` | bool | `false` | Enable auditor archetype (test quality gate) |
+
+### `[archetypes.instances]`
+
+Control how many parallel instances of an archetype run. Multiple instances
+produce independent findings that are then converged.
+
+| Key | Type | Default | Range | Description |
+|-----|------|---------|-------|-------------|
+| `skeptic` | int | `1` | 1–5 | Number of skeptic instances |
+| `verifier` | int | `1` | 1–5 | Number of verifier instances |
+| `auditor` | int | `1` | 1–5 | Number of auditor instances |
+
+### `[archetypes.skeptic_settings]`
+
+| Key | Type | Default | Range | Description |
+|-----|------|---------|-------|-------------|
+| `block_threshold` | int | `3` | 0+ | Block if majority-agreed critical findings exceed this count |
+
+### `[archetypes.oracle_settings]`
+
+| Key | Type | Default | Range | Description |
+|-----|------|---------|-------|-------------|
+| `block_threshold` | int | none | 1+ | Block if critical drift findings exceed this count (omit for advisory only) |
+
+### `[archetypes.auditor_config]`
+
+| Key | Type | Default | Range | Description |
+|-----|------|---------|-------|-------------|
+| `min_ts_entries` | int | `5` | 1+ | Minimum test_spec entries to trigger auditor injection |
+| `max_retries` | int | `2` | 0+ | Maximum auditor-coder retry iterations |
+
+### `[archetypes.models]`
+
+Per-archetype model tier overrides. These act as tier ceilings — the system
+may start lower but never escalates above the configured tier.
+
+```toml
+[archetypes.models]
+coder = "STANDARD"    # coder tasks will never use ADVANCED
+oracle = "STANDARD"   # oracle sessions use STANDARD tier
+```
+
+### `[archetypes.allowlists]`
+
+Per-archetype bash command allowlists.
+
+```toml
+[archetypes.allowlists]
+oracle = ["ls", "cat", "git", "grep", "find", "head", "tail", "wc"]
+```
+
+---
+
+## `[tools]`
+
+Fox tools configuration.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `fox_tools` | bool | `true` | Enable fox tools (token-efficient file operations) |
+
+---
+
+## `[pricing]`
+
+Configurable per-model pricing for cost calculations. If this section is
+absent, built-in defaults matching current Anthropic API rates are used.
+
+### `[pricing.models.<model-id>]`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `input_price_per_m` | float | varies | USD per million input tokens |
+| `output_price_per_m` | float | varies | USD per million output tokens |
+| `cache_read_price_per_m` | float | varies | USD per million cache-read input tokens |
+| `cache_creation_price_per_m` | float | varies | USD per million cache-creation input tokens |
+
+Default pricing:
+
+| Model | Input $/M | Output $/M | Cache Read $/M | Cache Create $/M |
+|-------|-----------|------------|----------------|------------------|
+| `claude-haiku-4-5` | `1.00` | `5.00` | `0.10` | `1.25` |
+| `claude-sonnet-4-6` | `3.00` | `15.00` | `0.30` | `3.75` |
+| `claude-opus-4-6` | `5.00` | `25.00` | `0.50` | `6.25` |
+
+Negative pricing values are clamped to zero with a warning.
+
+Example:
+
+```toml
+[pricing.models.claude-sonnet-4-6]
+input_price_per_m = 3.00
+output_price_per_m = 15.00
+cache_read_price_per_m = 0.30
+cache_creation_price_per_m = 3.75
+```
+
+---
+
+## `[planning]`
+
+Planning and dispatch configuration.
+
+| Key | Type | Default | Range | Description |
+|-----|------|---------|-------|-------------|
+| `duration_ordering` | bool | `true` | | Sort ready tasks by predicted duration (shortest first) |
+| `min_outcomes_for_historical` | int | `10` | 1–1000 | Min outcomes before using historical duration data |
+| `min_outcomes_for_regression` | int | `30` | 5–10000 | Min outcomes before training duration regression model |
+| `file_conflict_detection` | bool | `false` | | Detect file conflicts between parallel tasks |
+
+---
+
+## `[blocking]`
+
+Blocking threshold learning configuration.
+
+| Key | Type | Default | Range | Description |
+|-----|------|---------|-------|-------------|
+| `learn_thresholds` | bool | `false` | | Learn blocking thresholds from history |
+| `min_decisions_for_learning` | int | `20` | 1–1000 | Min blocking decisions before learning thresholds |
+| `max_false_negative_rate` | float | `0.1` | 0.0–1.0 | Maximum acceptable false negative rate |


### PR DESCRIPTION
## Summary

Comprehensive documentation refresh to bring docs in sync with the current implementation.

Closes #145

## Changes

| File | Change |
|------|--------|
| `docs/configuration.md` | New: complete configuration reference with all 13 TOML sections, types, defaults, and ranges |
| `docs/archetypes.md` | New: dedicated archetype reference covering all 7 archetypes with purpose, workflow, and config |
| `docs/cli-reference.md` | Updated: added `serve-tools` command, 6 missing flags, removed inline config (linked to new doc) |
| `README.md` | Updated: lighter content, fixed defaults, added Documentation section with links to new docs |

## Key Fixes

- Config defaults corrected: `skeptic`/`verifier` now show `true` (matching code since bb5c525)
- Added missing config sections: `[routing]`, `[planning]`, `[blocking]`, `[tools]`
- Added missing archetype: auditor (with full documentation)
- Added missing pricing fields: `cache_read_price_per_m`, `cache_creation_price_per_m`
- Removed stale platform config fields (`pr_granularity`, `wait_for_ci`, etc.)
- Added missing knowledge config fields: `confidence_threshold`, `fact_cache_enabled`

## Verification

- All existing tests pass: ✅ (2281 passed)
- Linter / formatter: ✅
- No regressions: ✅