### PR TITLE
feat(init): create seed files for memory.jsonl, state.jsonl, and docs/memory.md (fixes #170)

### DIFF
--- a/agent_fox/cli/init.py
+++ b/agent_fox/cli/init.py
@@ -202,9 +202,10 @@ def init_cmd(ctx: click.Context, skills: bool) -> None:
                 click.echo(
                     "Project is already initialized. Existing configuration preserved."
                 )
-        # Still ensure directory structure and gitignore are complete
+        # Still ensure directory structure, seed files, and gitignore are complete
         (agent_fox_dir / "hooks").mkdir(parents=True, exist_ok=True)
         (agent_fox_dir / "worktrees").mkdir(parents=True, exist_ok=True)
+        _ensure_seed_files(project_root)
         _update_gitignore(project_root)
         _ensure_develop_branch(quiet=json_mode)
         # 17-REQ-2.1: Merge canonical permissions on re-init
@@ -241,6 +242,9 @@ def init_cmd(ctx: click.Context, skills: bool) -> None:
 
     config_path.write_text(generate_default_config())
     logger.debug("Created default config.toml")
+
+    # Create seed files so they are tracked in git from the start
+    _ensure_seed_files(project_root)
 
     # 01-REQ-3.2: create or verify develop branch
     _ensure_develop_branch(quiet=json_mode)
@@ -376,6 +380,32 @@ def _ensure_claude_settings(project_root: Path) -> None:
         "Merged %d missing canonical permissions into settings",
         len(missing),
     )
+
+
+_DOCS_MEMORY_CONTENT = "# Agent-Fox Memory\n\n_No facts have been recorded yet._\n"
+
+
+def _ensure_seed_files(project_root: Path) -> None:
+    """Create empty seed files so they are tracked in git from the start.
+
+    Creates .agent-fox/memory.jsonl, .agent-fox/state.jsonl, and
+    docs/memory.md if they do not already exist. Idempotent — existing
+    files are never overwritten.
+    """
+    agent_fox_dir = project_root / ".agent-fox"
+
+    for name in ("memory.jsonl", "state.jsonl"):
+        path = agent_fox_dir / name
+        if not path.exists():
+            path.touch()
+            logger.debug("Created seed file %s", path)
+
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    docs_memory = docs_dir / "memory.md"
+    if not docs_memory.exists():
+        docs_memory.write_text(_DOCS_MEMORY_CONTENT, encoding="utf-8")
+        logger.debug("Created docs/memory.md")
 
 
 def _ensure_agents_md(project_root: Path) -> str:

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -153,6 +153,61 @@ class TestInitGitignore:
         assert "!.agent-fox/memory.jsonl" in gitignore
 
 
+class TestInitSeedFiles:
+    """Init creates seed files so they are tracked in git from the start."""
+
+    def test_init_creates_memory_jsonl(
+        self, cli_runner: CliRunner, tmp_git_repo: Path
+    ) -> None:
+        """init creates an empty .agent-fox/memory.jsonl."""
+        cli_runner.invoke(main, ["init"])
+
+        path = tmp_git_repo / ".agent-fox" / "memory.jsonl"
+        assert path.exists()
+        assert path.read_text() == ""
+
+    def test_init_creates_state_jsonl(
+        self, cli_runner: CliRunner, tmp_git_repo: Path
+    ) -> None:
+        """init creates an empty .agent-fox/state.jsonl."""
+        cli_runner.invoke(main, ["init"])
+
+        path = tmp_git_repo / ".agent-fox" / "state.jsonl"
+        assert path.exists()
+        assert path.read_text() == ""
+
+    def test_init_creates_docs_memory_md(
+        self, cli_runner: CliRunner, tmp_git_repo: Path
+    ) -> None:
+        """init creates docs/memory.md with placeholder content."""
+        cli_runner.invoke(main, ["init"])
+
+        path = tmp_git_repo / "docs" / "memory.md"
+        assert path.exists()
+        content = path.read_text()
+        assert "Agent-Fox Memory" in content
+
+    def test_reinit_preserves_existing_seed_files(
+        self, cli_runner: CliRunner, tmp_git_repo: Path
+    ) -> None:
+        """Re-running init does not overwrite existing seed files."""
+        cli_runner.invoke(main, ["init"])
+
+        # Write content to memory.jsonl
+        memory_path = tmp_git_repo / ".agent-fox" / "memory.jsonl"
+        memory_path.write_text('{"fact": "test"}\n')
+
+        # Write content to docs/memory.md
+        docs_memory = tmp_git_repo / "docs" / "memory.md"
+        docs_memory.write_text("# Custom content\n")
+
+        # Re-init
+        cli_runner.invoke(main, ["init"])
+
+        assert memory_path.read_text() == '{"fact": "test"}\n'
+        assert docs_memory.read_text() == "# Custom content\n"
+
+
 class TestInitClaudeSettings:
     """Integration tests for Claude settings creation (Spec 17).
 


### PR DESCRIPTION
## Summary

The `init` command now creates seed files (`memory.jsonl`, `state.jsonl`, `docs/memory.md`) so they are tracked in git from the start. Existing files are never overwritten.

Closes #170

## Changes

| File | Change |
|------|--------|
| `agent_fox/cli/init.py` | Added `_ensure_seed_files()` helper; called from both fresh-init and re-init paths |
| `tests/integration/test_init.py` | Added 4 tests: creation of each seed file + idempotency |

## Tests

- `TestInitSeedFiles::test_init_creates_memory_jsonl`
- `TestInitSeedFiles::test_init_creates_state_jsonl`
- `TestInitSeedFiles::test_init_creates_docs_memory_md`
- `TestInitSeedFiles::test_reinit_preserves_existing_seed_files`

## Verification

- All existing tests pass: ✅
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅ (2299 passed)

---
*Auto-generated by `af-fix`.*