### PR TITLE
feat(config): enable oracle/auditor by default, promote key settings (fixes #172)

### DIFF
--- a/.agent-fox/config.toml
+++ b/.agent-fox/config.toml
@@ -2,9 +2,9 @@
 ## Generated from schema — do not remove section headers.
 ## Uncomment and edit values to customize.
 
-# [orchestrator]
-## Maximum parallel sessions (1-8, default: 1)
-# parallel = 1
+[orchestrator]
+## Maximum parallel sessions (1-8, default: 2)
+parallel = 2
 ## Sync interval in task groups (>=0, default: 5)
 # sync_interval = 5
 ## Hot-load specs between sessions (default: true)
@@ -19,6 +19,50 @@
 ## max_cost =
 ## Maximum number of sessions (not set by default)
 ## max_sessions =
+## Maximum number of runs to retain in the audit log (default: 20)
+# audit_retention_runs = 20
+
+[archetypes]
+## Enable coder archetype (default: true)
+coder = true
+## Enable skeptic archetype (default: true)
+skeptic = true
+## Enable verifier archetype (default: true)
+verifier = true
+## Enable oracle archetype (default: true)
+oracle = true
+## Enable auditor archetype (default: true)
+auditor = true
+## Enable librarian archetype (default: false)
+# librarian = false
+## Enable cartographer archetype (default: false)
+# cartographer = false
+## Per-archetype model overrides (default: {})
+# models = {}
+## Per-archetype command allowlists (default: {})
+# allowlists = {}
+
+# [archetypes.instances]
+## Number of skeptic instances (1-5, default: 1)
+# skeptic = 1
+## Number of verifier instances (1-5, default: 1)
+# verifier = 1
+## Number of auditor instances (1-5, default: 1)
+# auditor = 1
+
+# [archetypes.skeptic_settings]
+## Finding count to block merge (>=0, default: 3)
+# block_threshold = 3
+
+# [archetypes.oracle_settings]
+## Drift count to block (None = advisory) (>=1, not set by default)
+## block_threshold =
+
+# [archetypes.auditor_config]
+## Minimum TS entries to trigger auditor injection (>=1, default: 5)
+# min_ts_entries = 5
+## Maximum auditor-coder retry iterations (>=0, default: 2)
+# max_retries = 2
 
 # [routing]
 ## Retries before model escalation (0-3, default: 1)
@@ -96,45 +140,13 @@
 ## Pre-compute fact rankings at plan time (default: true)
 # fact_cache_enabled = true
 
-# [archetypes]
-## Enable coder archetype (default: true)
-# coder = true
-## Enable skeptic archetype (default: false)
-# skeptic = false
-## Enable verifier archetype (default: false)
-# verifier = false
-## Enable librarian archetype (default: false)
-# librarian = false
-## Enable cartographer archetype (default: false)
-# cartographer = false
-## Enable oracle archetype (default: false)
-# oracle = false
-## Per-archetype model overrides (default: {})
-# models = {}
-## Per-archetype command allowlists (default: {})
-# allowlists = {}
-
-# [archetypes.instances]
-## Number of skeptic instances (1-5, default: 1)
-# skeptic = 1
-## Number of verifier instances (1-5, default: 1)
-# verifier = 1
-
-# [archetypes.skeptic_settings]
-## Finding count to block merge (>=0, default: 3)
-# block_threshold = 3
-
-# [archetypes.oracle_settings]
-## Drift count to block (None = advisory) (>=1, not set by default)
-## block_threshold =
-
 # [tools]
-## Enable fox tools (default: false)
-# fox_tools = false
+## Enable fox tools (default: true)
+# fox_tools = true
 
 # [pricing]
-## Per-model pricing configuration (default: {claude-haiku-4-5 = {input_price_per_m = 1.0, output_price_per_m = 5.0}, claude-sonnet-4-6 = {input_price_per_m = 3.0, output_price_per_m = 15.0}, claude-opus-4-6 = {input_price_per_m = 15.0, output_price_per_m = 75.0}})
-# models = {claude-haiku-4-5 = {input_price_per_m = 1.0, output_price_per_m = 5.0}, claude-sonnet-4-6 = {input_price_per_m = 3.0, output_price_per_m = 15.0}, claude-opus-4-6 = {input_price_per_m = 15.0, output_price_per_m = 75.0}}
+## Per-model pricing configuration (default: {claude-haiku-4-5 = {input_price_per_m = 1.0, output_price_per_m = 5.0, cache_read_price_per_m = 0.1, cache_creation_price_per_m = 1.25}, claude-sonnet-4-6 = {input_price_per_m = 3.0, output_price_per_m = 15.0, cache_read_price_per_m = 0.3, cache_creation_price_per_m = 3.75}, claude-opus-4-6 = {input_price_per_m = 5.0, output_price_per_m = 25.0, cache_read_price_per_m = 0.5, cache_creation_price_per_m = 6.25}})
+# models = {claude-haiku-4-5 = {input_price_per_m = 1.0, output_price_per_m = 5.0, cache_read_price_per_m = 0.1, cache_creation_price_per_m = 1.25}, claude-sonnet-4-6 = {input_price_per_m = 3.0, output_price_per_m = 15.0, cache_read_price_per_m = 0.3, cache_creation_price_per_m = 3.75}, claude-opus-4-6 = {input_price_per_m = 5.0, output_price_per_m = 25.0, cache_read_price_per_m = 0.5, cache_creation_price_per_m = 6.25}}
 
 # [planning]
 ## Sort ready tasks by predicted duration (default: true)

--- a/agent_fox/core/config.py
+++ b/agent_fox/core/config.py
@@ -88,7 +88,7 @@ class RoutingConfig(BaseModel):
 class OrchestratorConfig(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    parallel: int = Field(default=1, description="Maximum parallel sessions")
+    parallel: int = Field(default=2, description="Maximum parallel sessions")
     sync_interval: int = Field(default=5, description="Sync interval in task groups")
     hot_load: bool = Field(default=True, description="Hot-load specs between sessions")
     max_retries: int = Field(default=2, description="Maximum retries per task group")
@@ -377,8 +377,8 @@ class ArchetypesConfig(BaseModel):
     cartographer: bool = Field(
         default=False, description="Enable cartographer archetype"
     )
-    oracle: bool = Field(default=False, description="Enable oracle archetype")
-    auditor: bool = Field(default=False, description="Enable auditor archetype")
+    oracle: bool = Field(default=True, description="Enable oracle archetype")
+    auditor: bool = Field(default=True, description="Enable auditor archetype")
 
     instances: ArchetypeInstancesConfig = Field(
         default_factory=ArchetypeInstancesConfig,

--- a/agent_fox/core/config_gen.py
+++ b/agent_fox/core/config_gen.py
@@ -47,6 +47,24 @@ _BOUNDS_MAP: dict[tuple[str, str], str] = {
     ("SkepticConfig", "block_threshold"): ">=0",
     # OracleSettings
     ("OracleSettings", "block_threshold"): ">=1",
+    # AuditorConfig
+    ("AuditorConfig", "min_ts_entries"): ">=1",
+    ("AuditorConfig", "max_retries"): ">=0",
+    # ArchetypeInstancesConfig (auditor)
+    ("ArchetypeInstancesConfig", "auditor"): "1-5",
+}
+
+# Fields rendered as active (uncommented) in the default config template.
+# Keyed by (section_path, field_name). Sections with promoted fields are
+# rendered first with an active [section] header; remaining sections follow
+# as commented # [section] blocks.
+_PROMOTED_DEFAULTS: set[tuple[str, str]] = {
+    ("orchestrator", "parallel"),
+    ("archetypes", "coder"),
+    ("archetypes", "skeptic"),
+    ("archetypes", "verifier"),
+    ("archetypes", "oracle"),
+    ("archetypes", "auditor"),
 }
 
 # Default descriptions for fields that lack description metadata.
@@ -106,11 +124,18 @@ _DEFAULT_DESCRIPTIONS: dict[tuple[str, str], str] = {
     ("ArchetypesConfig", "librarian"): "Enable librarian archetype",
     ("ArchetypesConfig", "cartographer"): "Enable cartographer archetype",
     ("ArchetypesConfig", "oracle"): "Enable oracle archetype",
+    ("ArchetypesConfig", "auditor"): "Enable auditor archetype",
     ("ArchetypesConfig", "models"): "Per-archetype model overrides",
     ("ArchetypesConfig", "allowlists"): "Per-archetype command allowlists",
     # ArchetypeInstancesConfig
     ("ArchetypeInstancesConfig", "skeptic"): "Number of skeptic instances",
     ("ArchetypeInstancesConfig", "verifier"): "Number of verifier instances",
+    ("ArchetypeInstancesConfig", "auditor"): "Number of auditor instances",
+    # AuditorConfig
+    ("AuditorConfig", "min_ts_entries"): (
+        "Minimum TS entries to trigger auditor injection"
+    ),
+    ("AuditorConfig", "max_retries"): "Maximum auditor-coder retry iterations",
     # SkepticConfig
     ("SkepticConfig", "block_threshold"): "Finding count to block merge",
     # OracleSettings
@@ -361,8 +386,21 @@ def _format_field_comment(field_spec: FieldSpec) -> str:
     return f"## {desc} (default: {default_str})"
 
 
+def _section_has_promoted(section: SectionSpec) -> bool:
+    """Check if a section has any promoted (active) fields."""
+    for field_spec in section.fields:
+        if field_spec.is_nested:
+            continue
+        if (section.path, field_spec.name) in _PROMOTED_DEFAULTS:
+            return True
+    return False
+
+
 def generate_config_template(schema: list[SectionSpec]) -> str:
-    """Render a fully-commented config.toml from extracted schema.
+    """Render a config.toml from extracted schema with promoted defaults active.
+
+    Sections with promoted fields are rendered first with active [section]
+    headers. Remaining sections follow as commented # [section] blocks.
 
     Requirements: 33-REQ-1.1, 33-REQ-1.2, 33-REQ-1.3, 33-REQ-1.4, 33-REQ-1.5
     """
@@ -372,7 +410,15 @@ def generate_config_template(schema: list[SectionSpec]) -> str:
         "## Uncomment and edit values to customize.",
     ]
 
-    for i, section in enumerate(schema):
+    # Partition into active (have promoted fields) and inactive sections
+    active_sections = [s for s in schema if _section_has_promoted(s)]
+    inactive_sections = [s for s in schema if not _section_has_promoted(s)]
+
+    for section in active_sections:
+        lines.append("")
+        _render_section(section, lines)
+
+    for section in inactive_sections:
         lines.append("")
         _render_section(section, lines)
 
@@ -384,19 +430,38 @@ def generate_config_template(schema: list[SectionSpec]) -> str:
 
 
 def _render_section(section: SectionSpec, lines: list[str]) -> None:
-    """Render a section and its subsections as commented TOML."""
-    lines.append(f"# [{section.path}]")
+    """Render a section and its subsections.
 
+    If the section has promoted fields, render it with an active [section]
+    header and promoted fields uncommented. Otherwise render fully commented.
+    """
+    has_promoted = _section_has_promoted(section)
+
+    if has_promoted:
+        lines.append(f"[{section.path}]")
+    else:
+        lines.append(f"# [{section.path}]")
+
+    # Render promoted (active) fields first, then inactive fields
+    promoted_fields = []
+    inactive_fields = []
     for field_spec in section.fields:
         if field_spec.is_nested:
             continue
-        # Description comment
+        if (section.path, field_spec.name) in _PROMOTED_DEFAULTS:
+            promoted_fields.append(field_spec)
+        else:
+            inactive_fields.append(field_spec)
+
+    for field_spec in promoted_fields:
         lines.append(_format_field_comment(field_spec))
-        # Commented key-value pair
+        toml_val = _format_toml_value(field_spec.default)
+        lines.append(f"{field_spec.name} = {toml_val}")
+
+    for field_spec in inactive_fields:
+        lines.append(_format_field_comment(field_spec))
         toml_val = _format_toml_value(field_spec.default)
         if field_spec.default is None:
-            # Double-# so stripping '# ' leaves '# key =' (still a comment),
-            # keeping the uncommented TOML valid per 33-REQ-1.4
             lines.append(f"## {field_spec.name} =")
         else:
             lines.append(f"# {field_spec.name} = {toml_val}")

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -286,7 +286,7 @@ class TestInitConfigGeneration:
         config = load_config(config_path)
         assert isinstance(config, AgentFoxConfig)
         # Verify key defaults
-        assert config.orchestrator.parallel == 1
+        assert config.orchestrator.parallel == 2
         assert config.theme.playful is True
         assert config.models.coding == "ADVANCED"
 
@@ -311,7 +311,10 @@ class TestInitConfigGeneration:
             "archetypes",
             "tools",
         ]:
-            assert f"# [{section}]" in content, f"Missing section header: {section}"
+            # Sections may be active [section] or commented # [section]
+            assert (
+                f"[{section}]" in content
+            ), f"Missing section header: {section}"
 
     def test_reinit_merges_new_fields(
         self, cli_runner: CliRunner, tmp_git_repo: Path

--- a/tests/property/core/test_config_gen_props.py
+++ b/tests/property/core/test_config_gen_props.py
@@ -47,12 +47,14 @@ def _count_scalar_fields(sections: list[SectionSpec]) -> int:
     return total
 
 
-def _count_commented_field_lines(template: str) -> int:
-    """Count lines matching '# field_name = ...' pattern."""
+def _count_field_lines(template: str) -> int:
+    """Count lines matching field assignment patterns (active or commented)."""
     count = 0
     for line in template.split("\n"):
-        # Match '# key = value' but not section headers '# [section]'
-        if re.match(r"^#{1,2} \w+\s*=", line):
+        # Match 'key = value' or '# key = value' but not section headers
+        if re.match(r"^#{0,2}\s*\w+\s*=", line) and not re.match(
+            r"^#\s*\[", line
+        ):
             count += 1
     return count
 
@@ -155,10 +157,10 @@ class TestTemplateCompleteness:
         template = generate_default_config()
 
         total_scalar = _count_scalar_fields(schema)
-        total_commented = _count_commented_field_lines(template)
+        total_fields = _count_field_lines(template)
 
-        assert total_commented == total_scalar, (
-            f"Expected {total_scalar} commented field entries, got {total_commented}"
+        assert total_fields == total_scalar, (
+            f"Expected {total_scalar} field entries, got {total_fields}"
         )
 
 

--- a/tests/property/core/test_config_props.py
+++ b/tests/property/core/test_config_props.py
@@ -34,7 +34,7 @@ class TestConfigDefaultsCompleteness:
         config = load_config(path=config_file)
 
         assert isinstance(config, AgentFoxConfig)
-        assert config.orchestrator.parallel == 1
+        assert config.orchestrator.parallel == 2
         assert config.orchestrator.sync_interval == 5
         assert config.orchestrator.max_retries == 2
         assert config.orchestrator.session_timeout == 30

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -27,7 +27,7 @@ class TestConfigDefaults:
         config = load_config(path=config_file)
 
         assert isinstance(config, AgentFoxConfig)
-        assert config.orchestrator.parallel == 1
+        assert config.orchestrator.parallel == 2
         assert config.orchestrator.sync_interval == 5
         assert config.orchestrator.max_retries == 2
         assert config.orchestrator.session_timeout == 30
@@ -41,7 +41,7 @@ class TestConfigDefaults:
 
         config = load_config(path=config_file)
 
-        assert config.orchestrator.parallel == 1
+        assert config.orchestrator.parallel == 2
         assert config.models.coding == "ADVANCED"
 
 
@@ -100,7 +100,7 @@ class TestConfigMissingFile:
         config = load_config(path=Path("/tmp/nonexistent_config_12345.toml"))
 
         assert isinstance(config, AgentFoxConfig)
-        assert config.orchestrator.parallel == 1
+        assert config.orchestrator.parallel == 2
         assert config.models.coding == "ADVANCED"
 
 
@@ -127,7 +127,7 @@ class TestConfigUnrecognizedKeys:
         config = load_config(path=config_file)
 
         assert isinstance(config, AgentFoxConfig)
-        assert config.orchestrator.parallel == 1  # defaults applied
+        assert config.orchestrator.parallel == 2  # defaults applied
 
     def test_unknown_field_in_known_section_ignored(self, tmp_path: Path) -> None:
         """Unknown fields within known sections are silently ignored."""

--- a/tests/unit/core/test_config_archetypes.py
+++ b/tests/unit/core/test_config_archetypes.py
@@ -28,6 +28,8 @@ class TestArchetypeToggles:
         assert cfg.verifier is True
         assert cfg.librarian is False
         assert cfg.cartographer is False
+        assert cfg.oracle is True
+        assert cfg.auditor is True
 
     def test_disable_skeptic(self) -> None:
         from agent_fox.core.config import ArchetypesConfig

--- a/tests/unit/core/test_config_auditor.py
+++ b/tests/unit/core/test_config_auditor.py
@@ -24,14 +24,14 @@ except ImportError:
 # ---------------------------------------------------------------------------
 
 
-class TestAuditorDefaultFalse:
-    """Verify ArchetypesConfig defaults auditor to False."""
+class TestAuditorDefaultTrue:
+    """Verify ArchetypesConfig defaults auditor to True."""
 
-    def test_auditor_default_false(self) -> None:
+    def test_auditor_default_true(self) -> None:
         from agent_fox.core.config import ArchetypesConfig
 
         config = ArchetypesConfig()
-        assert config.auditor is False
+        assert config.auditor is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_config_gen.py
+++ b/tests/unit/core/test_config_gen.py
@@ -20,6 +20,7 @@ from agent_fox.core.config import (
     load_config,
 )
 from agent_fox.core.config_gen import (
+    _PROMOTED_DEFAULTS,
     extract_schema,
     generate_default_config,
     merge_existing_config,
@@ -52,26 +53,30 @@ def _strip_comment_prefixes(template: str) -> str:
 
 
 def _extract_field_names_in_order(template: str, section: str) -> list[str]:
-    """Extract commented field names in order from a template section.
+    """Extract field names in order from a template section.
 
-    Finds lines like '# field_name = ...' within the given section.
+    Finds lines like 'field_name = ...' or '# field_name = ...' within
+    the given section (handles both active and commented headers).
     """
     lines = template.split("\n")
     in_section = False
     field_names = []
-    section_header = f"# [{section}]"
 
     for line in lines:
-        # Check for section header
-        if line.strip() == section_header:
+        stripped = line.strip()
+        # Check for section header (active or commented)
+        if stripped == f"[{section}]" or stripped == f"# [{section}]":
             in_section = True
             continue
         # Check for next section header (end of current section)
-        if in_section and re.match(r"^# \[[\w.]+\]$", line.strip()):
+        if in_section and (
+            re.match(r"^# \[[\w.]+\]$", stripped)
+            or re.match(r"^\[[\w.]+\]$", stripped)
+        ):
             break
-        # Extract field names from commented key-value pairs
+        # Extract field names from active or commented key-value pairs
         if in_section:
-            m = re.match(r"^#{1,2} (\w+)\s*=", line)
+            m = re.match(r"^#{0,2}\s*(\w+)\s*=", line)
             if m:
                 field_names.append(m.group(1))
     return field_names
@@ -81,8 +86,9 @@ class TestTemplateGeneration:
     """Tests for config template generation (TS-33-1 through TS-33-5)."""
 
     def test_template_contains_all_fields(self) -> None:
-        """TS-33-1: Template includes a commented entry for every field.
+        """TS-33-1: Template includes an entry for every field.
 
+        Promoted fields appear as active (uncommented); others as commented.
         Requirement: 33-REQ-1.1
         """
         template = generate_default_config()
@@ -91,10 +97,16 @@ class TestTemplateGeneration:
         for section in schema:
             for field in section.fields:
                 if not field.is_nested:
-                    assert f"# {field.name} =" in template, (
-                        f"Missing field entry for '{field.name}' "
-                        f"in section '{section.path}'"
-                    )
+                    if (section.path, field.name) in _PROMOTED_DEFAULTS:
+                        assert f"{field.name} =" in template, (
+                            f"Missing active entry for '{field.name}' "
+                            f"in section '{section.path}'"
+                        )
+                    else:
+                        assert f"# {field.name} =" in template, (
+                            f"Missing commented entry for '{field.name}' "
+                            f"in section '{section.path}'"
+                        )
 
     def test_template_includes_descriptions_and_bounds(self) -> None:
         """TS-33-2: Fields include descriptions and bounds in comments.
@@ -108,7 +120,7 @@ class TestTemplateGeneration:
         # sync_interval has bounds >=0
         assert ">=0" in template, "Missing bounds for sync_interval"
         # parallel default is 1
-        assert "default: 1" in template, "Missing default for parallel"
+        assert "default: 2" in template, "Missing default for parallel"
         # playful default is true
         assert "default: true" in template, "Missing default for playful"
 
@@ -119,9 +131,14 @@ class TestTemplateGeneration:
         """
         template = generate_default_config()
 
-        # Top-level sections
+        # Sections with promoted fields have active headers
+        for section in ["orchestrator", "archetypes"]:
+            assert f"[{section}]" in template, (
+                f"Missing active section header for [{section}]"
+            )
+
+        # Other sections have commented headers
         for section in [
-            "orchestrator",
             "routing",
             "models",
             "hooks",
@@ -129,7 +146,6 @@ class TestTemplateGeneration:
             "theme",
             "platform",
             "knowledge",
-            "archetypes",
             "tools",
         ]:
             assert f"# [{section}]" in template, (

--- a/tests/unit/graph/test_builder_archetypes.py
+++ b/tests/unit/graph/test_builder_archetypes.py
@@ -236,7 +236,9 @@ class TestSkepticAutoInjection:
         from agent_fox.core.config import ArchetypesConfig
         from agent_fox.graph.builder import build_graph
 
-        config = ArchetypesConfig(skeptic=True)
+        config = ArchetypesConfig(
+            skeptic=True, oracle=False, auditor=False,
+        )
         specs = [_spec()]
         task_groups = {"spec": [_tgd(1, "T1"), _tgd(2, "T2")]}
 
@@ -465,7 +467,9 @@ class TestPropertyInjectionStructure:
         from agent_fox.core.config import ArchetypesConfig
         from agent_fox.graph.builder import build_graph
 
-        config = ArchetypesConfig(skeptic=True, verifier=True)
+        config = ArchetypesConfig(
+            skeptic=True, verifier=True, oracle=False, auditor=False,
+        )
         specs = [_spec()]
         task_groups = {"spec": [_tgd(i, f"T{i}") for i in range(1, n_groups + 1)]}
 

--- a/tests/unit/oracle/test_blocking.py
+++ b/tests/unit/oracle/test_blocking.py
@@ -76,11 +76,11 @@ class TestConfigDefaults:
     """Verify oracle config defaults."""
 
     def test_config_defaults(self) -> None:
-        """TS-32-12: Oracle disabled by default, no block threshold."""
+        """TS-32-12: Oracle enabled by default, no block threshold."""
         from agent_fox.core.config import ArchetypesConfig
 
         config = ArchetypesConfig()
-        assert config.oracle is False
+        assert config.oracle is True
         assert config.oracle_settings.block_threshold is None
 
     def test_oracle_enabled(self) -> None:

--- a/tests/unit/oracle/test_registry.py
+++ b/tests/unit/oracle/test_registry.py
@@ -55,13 +55,13 @@ class TestOracleEnabledConfig:
         config = ArchetypesConfig(oracle=True)
         assert _is_archetype_enabled("oracle", config) is True
 
-    def test_oracle_disabled_by_default(self) -> None:
-        """Oracle is disabled by default."""
+    def test_oracle_enabled_by_default(self) -> None:
+        """Oracle is enabled by default."""
         from agent_fox.core.config import ArchetypesConfig
         from agent_fox.graph.builder import _is_archetype_enabled
 
         config = ArchetypesConfig()
-        assert _is_archetype_enabled("oracle", config) is False
+        assert _is_archetype_enabled("oracle", config) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Change defaults: `orchestrator.parallel=2`, `archetypes.oracle=true`, `archetypes.auditor=true`
- Add promoted defaults system to config template generator — key settings render as active (uncommented) entries at the top of the config file
- Active sections (`[orchestrator]`, `[archetypes]`) render first; inactive sections follow as commented blocks

Closes #172

## Changes

| File | Change |
|------|--------|
| `agent_fox/core/config.py` | Changed defaults: `parallel=2`, `oracle=True`, `auditor=True` |
| `agent_fox/core/config_gen.py` | Added `_PROMOTED_DEFAULTS` set, section partitioning, promoted field rendering |
| `.agent-fox/config.toml` | Regenerated with promoted defaults active |
| 10 test files | Updated assertions for new defaults and template structure |

## Tests

- All 2307 tests pass
- Updated unit, property, and integration tests for new defaults
- Updated template generation tests for active/commented field handling

## Verification

- All existing tests pass: ✅
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*