### PR TITLE
fix(cli): remove broken audit and serve-tools CLI commands (fixes #174)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,23 +120,6 @@ four tools with the agent backend:
 | `fox_edit` | Hash-verified atomic batch editing (prevents stale-read corruption) |
 | `fox_search` | Regex search with context lines and content hashes |
 
-### MCP Server
-
-The fox tools are also available as an MCP server for external consumers
-(other agents, IDEs, MCP-compatible clients):
-
-```bash
-# Launch the MCP server on stdio
-agent-fox serve-tools
-
-# Restrict file operations to specific directories
-agent-fox serve-tools --allowed-dirs /path/to/project --allowed-dirs /path/to/other
-```
-
-The MCP server exposes the same four tools over the standard MCP stdio
-transport. Path sandboxing via `--allowed-dirs` restricts file operations to
-the specified directories and their descendants.
-
 ## Dependencies
 
 ### DuckDB (Required)

--- a/agent_fox/cli/app.py
+++ b/agent_fox/cli/app.py
@@ -127,18 +127,15 @@ def main(ctx: click.Context, verbose: bool, quiet: bool, json_mode: bool) -> Non
 
 
 # Import and register subcommands
-from agent_fox.cli.audit import audit_cmd  # noqa: E402
 from agent_fox.cli.code import code_cmd  # noqa: E402
 from agent_fox.cli.fix import fix_cmd  # noqa: E402
 from agent_fox.cli.init import init_cmd  # noqa: E402
 from agent_fox.cli.lint_spec import lint_spec  # noqa: E402
 from agent_fox.cli.plan import plan_cmd  # noqa: E402
 from agent_fox.cli.reset import reset_cmd  # noqa: E402
-from agent_fox.cli.serve_tools import serve_tools_cmd  # noqa: E402
 from agent_fox.cli.standup import standup_cmd  # noqa: E402
 from agent_fox.cli.status import status_cmd  # noqa: E402
 
-main.add_command(audit_cmd, name="audit")
 main.add_command(code_cmd, name="code")
 main.add_command(fix_cmd, name="fix")
 main.add_command(init_cmd, name="init")
@@ -146,5 +143,4 @@ main.add_command(lint_spec, name="lint-spec")
 main.add_command(plan_cmd, name="plan")
 main.add_command(reset_cmd, name="reset")
 main.add_command(standup_cmd, name="standup")
-main.add_command(serve_tools_cmd, name="serve-tools")
 main.add_command(status_cmd, name="status")

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -13,9 +13,7 @@ Complete reference for all `agent-fox` commands, options, and configuration.
 | `agent-fox standup` | Generate daily activity report |
 | `agent-fox fix` | Detect and auto-fix quality check failures |
 | `agent-fox reset` | Reset failed/blocked tasks for retry |
-| `agent-fox audit` | Query the structured audit log |
 | `agent-fox lint-spec` | Validate specification files |
-| `agent-fox serve-tools` | Launch fox tools MCP server |
 
 ## Global Options
 
@@ -299,58 +297,6 @@ Hard reset requires confirmation unless `--yes` or `--json` is provided.
 
 ---
 
-### audit
-
-Query the structured audit log.
-
-```
-agent-fox audit [OPTIONS]
-```
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `--list-runs` | flag | off | List available run IDs with timestamps and event counts |
-| `--run ID` | string | none | Filter events by run ID |
-| `--event-type TYPE` | string | none | Filter events by event type (e.g. `session.complete`) |
-| `--node-id ID` | string | none | Filter events by node ID |
-| `--since WHEN` | string | none | Filter events after datetime (ISO-8601 or relative: `24h`, `7d`) |
-
-Queries the DuckDB-backed audit log for events emitted during orchestrator
-runs. Each orchestrator invocation generates a unique run ID and emits
-structured events covering session lifecycle, tool usage, model routing,
-git operations, and knowledge harvesting.
-
-Use `agent-fox --json audit` for structured JSON output.
-
-**Event types:** `run.start`, `run.complete`, `run.limit_reached`,
-`session.start`, `session.complete`, `session.fail`, `session.retry`,
-`task.status_change`, `model.escalation`, `model.assessment`,
-`tool.invocation`, `tool.error`, `git.merge`, `git.conflict`,
-`harvest.complete`, `fact.extracted`, `fact.compacted`,
-`knowledge.ingested`, `sync.barrier`.
-
-**Examples:**
-
-```bash
-# List all runs
-agent-fox audit --list-runs
-
-# Show events from a specific run
-agent-fox audit --run 20260312_143000_abc123
-
-# Show only session completions from the last 24 hours
-agent-fox audit --event-type session.complete --since 24h
-
-# JSON output for scripting
-agent-fox --json audit --list-runs
-```
-
-**Exit codes:** `0` always (empty results are not errors). If the DuckDB
-database does not exist or the `audit_events` table is missing, a message
-indicates no audit data is available.
-
----
-
 ### lint-spec
 
 Validate specification files.
@@ -386,25 +332,6 @@ re-validated to produce the final findings list. If the AI rewrite call fails,
 the original criteria are left unchanged.
 
 **Exit codes:** `0` no errors (warnings OK), `1` error-severity findings.
-
----
-
-### serve-tools
-
-Launch the fox tools MCP server on stdio.
-
-```
-agent-fox serve-tools [OPTIONS]
-```
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `--allowed-dirs PATH` | path (multiple) | none | Restrict file operations to these directories |
-
-Exposes the four fox tools (`fox_outline`, `fox_read`, `fox_edit`,
-`fox_search`) over the standard MCP stdio transport. Path sandboxing via
-`--allowed-dirs` restricts file operations to the specified directories and
-their descendants.
 
 ---
 

--- a/tests/integration/tools/test_mcp_server.py
+++ b/tests/integration/tools/test_mcp_server.py
@@ -1,7 +1,7 @@
 """MCP server integration tests.
 
 Test Spec: TS-29-22 (four tools), TS-29-23 (delegates to core),
-           TS-29-24 (CLI command), TS-29-25 (allowed-dirs),
+           TS-29-25 (allowed-dirs),
            TS-29-E16 (path blocked), TS-29-E17 (clean shutdown)
 Requirements: 29-REQ-7.1, 29-REQ-7.2, 29-REQ-7.3, 29-REQ-7.4,
               29-REQ-7.E1, 29-REQ-7.E2
@@ -12,7 +12,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from click.testing import CliRunner
 
 
 class TestMCPFourToolsRegistered:
@@ -43,18 +42,6 @@ class TestMCPDelegatesToCore:
         # MCP result is a text string; verify each direct line's hash appears
         for hl in direct.lines:
             assert hl.hash in mcp_result
-
-
-class TestMCPCLICommand:
-    """TS-29-24: serve-tools is a registered CLI command."""
-
-    def test_cli_command(self) -> None:
-        from agent_fox.cli.app import main
-
-        runner = CliRunner()
-        result = runner.invoke(main, ["serve-tools", "--help"])
-        assert result.exit_code == 0
-        assert "mcp" in result.output.lower() or "MCP" in result.output
 
 
 class TestMCPAllowedDirs:


### PR DESCRIPTION
## Summary

Remove the `audit` and `serve-tools` commands from the CLI entry point and all documentation. The underlying code modules are preserved as requested in the issue.

Closes #174

## Changes

| File | Change |
|------|--------|
| `agent_fox/cli/app.py` | Removed import and `add_command()` registration for `audit_cmd` and `serve_tools_cmd` |
| `docs/cli-reference.md` | Removed quick reference entries and detailed sections for `audit` and `serve-tools` |
| `README.md` | Removed MCP Server section referencing `serve-tools` |
| `tests/integration/tools/test_mcp_server.py` | Removed `TestMCPCLICommand` class (tested the now-removed CLI command) |

## Tests

- Existing audit unit tests (`tests/unit/cli/test_audit_cli.py`) still pass — they import `audit_cmd` directly
- Removed `TestMCPCLICommand` which tested the CLI registration of `serve-tools`

## Verification

- All existing tests pass: ✅ (1 pre-existing failure unrelated to this change)
- Linter / formatter: ✅
- No regressions: ✅