### PR TITLE
fix(cli): guard cleanup steps independently in finally block (fixes #194)

### DIFF
--- a/agent_fox/cli/code.py
+++ b/agent_fox/cli/code.py
@@ -505,10 +505,19 @@ def code_cmd(
         # 12-REQ-4.1, 12-REQ-4.2: Re-ingest to capture new commits/ADRs
         _run_ingestion(knowledge_db, config)
         # 39-REQ-3.2: Export all non-superseded facts to JSONL at session end
-        export_facts_to_jsonl(knowledge_db.connection, DEFAULT_MEMORY_PATH)
+        try:
+            export_facts_to_jsonl(knowledge_db.connection, DEFAULT_MEMORY_PATH)
+        except Exception:
+            logger.warning("Final JSONL export failed", exc_info=True)
         # Clean up knowledge store connection
-        sink_dispatcher.close()
-        knowledge_db.close()
+        try:
+            sink_dispatcher.close()
+        except Exception:
+            logger.warning("Sink dispatcher close failed", exc_info=True)
+        try:
+            knowledge_db.close()
+        except Exception:
+            logger.warning("Knowledge DB close failed", exc_info=True)
 
     # 23-REQ-5.1: emit JSONL summary in JSON mode
     if json_mode:

--- a/tests/unit/cli/test_code.py
+++ b/tests/unit/cli/test_code.py
@@ -730,3 +730,70 @@ class TestNodeSessionRunnerHarvestError:
 
         assert result is not None
         assert result["summary"] == "Implemented task group 1."
+
+
+class TestFinallyBlockCleanup:
+    """Regression test for issue #194: cleanup steps must run independently.
+
+    Each cleanup step in the finally block should be guarded so that a
+    failure in one step does not prevent subsequent steps from executing.
+    """
+
+    def test_cleanup_continues_after_export_failure(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """sink_dispatcher.close() and knowledge_db.close() run even when
+        export_facts_to_jsonl raises."""
+        state = _make_execution_state(run_status="completed")
+        mock_orch = MagicMock()
+        mock_orch.run = AsyncMock(return_value=state)
+        mock_kb = MagicMock(spec=KnowledgeDB)
+        mock_sink = MagicMock()
+
+        with (
+            patch("agent_fox.cli.code.Orchestrator", return_value=mock_orch),
+            patch("agent_fox.cli.code.PLAN_PATH") as mock_plan_path,
+            patch("agent_fox.cli.code.open_knowledge_store", return_value=mock_kb),
+            patch(
+                "agent_fox.cli.code.SinkDispatcher", return_value=mock_sink
+            ),
+            patch(
+                "agent_fox.cli.code.export_facts_to_jsonl",
+                side_effect=RuntimeError("DuckDB lock contention"),
+            ),
+            patch("agent_fox.cli.code._run_ingestion"),
+        ):
+            mock_plan_path.exists.return_value = True
+            result = cli_runner.invoke(main, ["code"])
+
+        # Both close methods must have been called despite the export failure
+        mock_sink.close.assert_called_once()
+        mock_kb.close.assert_called_once()
+        assert result.exit_code == 0
+
+    def test_cleanup_continues_after_sink_close_failure(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """knowledge_db.close() runs even when sink_dispatcher.close() raises."""
+        state = _make_execution_state(run_status="completed")
+        mock_orch = MagicMock()
+        mock_orch.run = AsyncMock(return_value=state)
+        mock_kb = MagicMock(spec=KnowledgeDB)
+        mock_sink = MagicMock()
+        mock_sink.close.side_effect = RuntimeError("sink error")
+
+        with (
+            patch("agent_fox.cli.code.Orchestrator", return_value=mock_orch),
+            patch("agent_fox.cli.code.PLAN_PATH") as mock_plan_path,
+            patch("agent_fox.cli.code.open_knowledge_store", return_value=mock_kb),
+            patch(
+                "agent_fox.cli.code.SinkDispatcher", return_value=mock_sink
+            ),
+            patch("agent_fox.cli.code.export_facts_to_jsonl"),
+            patch("agent_fox.cli.code._run_ingestion"),
+        ):
+            mock_plan_path.exists.return_value = True
+            result = cli_runner.invoke(main, ["code"])
+
+        mock_kb.close.assert_called_once()
+        assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Wraps each cleanup step in the `code` command's `finally` block with independent try/except guards so that a failure in one step does not skip subsequent steps. This fixes the bug where `memory.jsonl` export failures would also prevent `sink_dispatcher.close()` and `knowledge_db.close()` from running.

Closes #194

## Changes

| File | Change |
|------|--------|
| `agent_fox/cli/code.py` | Wrap `export_facts_to_jsonl`, `sink_dispatcher.close()`, and `knowledge_db.close()` in independent try/except blocks with warning-level logging |
| `tests/unit/cli/test_code.py` | Add `TestFinallyBlockCleanup` with 2 regression tests verifying cleanup continues after export and sink failures |

## Tests

- `test_cleanup_continues_after_export_failure` — verifies close methods run when export raises RuntimeError
- `test_cleanup_continues_after_sink_close_failure` — verifies DB close runs when sink close raises

## Verification

- All existing tests pass: ✅ (2609 → 2611)
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*