### PR TITLE
fix(workspace): prevent git argument injection via ref name validation (fixes #189)

### DIFF
--- a/agent_fox/workspace/__init__.py
+++ b/agent_fox/workspace/__init__.py
@@ -27,6 +27,7 @@ from agent_fox.workspace.git import (  # noqa: F401
     rebase_onto,
     remote_branch_exists,
     run_git,
+    validate_ref_name,
 )
 from agent_fox.workspace.worktree import (  # noqa: F401
     WorkspaceInfo,

--- a/agent_fox/workspace/git.py
+++ b/agent_fox/workspace/git.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 from pathlib import Path
 
 from agent_fox.core.errors import IntegrationError, WorkspaceError
@@ -31,6 +32,29 @@ _REMOTE_SUBCOMMANDS = frozenset(
         "ls-remote",
     }
 )
+
+# Safe ref name pattern: alphanumeric, dots, underscores, hyphens, slashes, @.
+# Rejects: leading dash, spaces, colons, tildes, carets, double-dots,
+# backslashes, @{ sequences, and other characters unsafe in git refs.
+_REF_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_./@-]*$")
+
+
+def validate_ref_name(name: str) -> str:
+    """Validate a git ref name to prevent argument injection.
+
+    Rejects names that start with ``-`` (which git would interpret as
+    flags), empty strings, and names containing characters unsafe in
+    git refs (spaces, colons, tildes, carets, double-dots, backslashes,
+    ``@{`` sequences).
+
+    Returns the name unchanged if valid, raises WorkspaceError otherwise.
+    """
+    if not name or not _REF_NAME_RE.fullmatch(name) or ".." in name or "@{" in name:
+        raise WorkspaceError(
+            f"Invalid git ref name: {name!r}",
+            ref_name=name,
+        )
+    return name
 
 
 async def run_git(
@@ -102,9 +126,11 @@ async def create_branch(
     """Create a new git branch at the given start point.
 
     Raises:
-        WorkspaceError: If branch creation fails.
+        WorkspaceError: If branch creation fails or ref names are invalid.
     """
-    await run_git(["branch", branch_name, start_point], cwd=repo_path)
+    validate_ref_name(branch_name)
+    validate_ref_name(start_point)
+    await run_git(["branch", "--", branch_name, start_point], cwd=repo_path)
 
 
 async def delete_branch(
@@ -120,9 +146,10 @@ async def delete_branch(
         WorkspaceError: If deletion fails for reasons other than
             the branch not existing.
     """
+    validate_ref_name(branch_name)
     flag = "-D" if force else "-d"
     returncode, _stdout, stderr = await run_git(
-        ["branch", flag, branch_name],
+        ["branch", flag, "--", branch_name],
         cwd=repo_path,
         check=False,
     )
@@ -148,8 +175,9 @@ async def checkout_branch(
     """Check out a branch in the given working directory.
 
     Raises:
-        WorkspaceError: If checkout fails.
+        WorkspaceError: If checkout fails or ref name is invalid.
     """
+    validate_ref_name(branch_name)
     await run_git(["checkout", branch_name], cwd=repo_path)
 
 
@@ -163,6 +191,8 @@ async def has_new_commits(
     Returns True if there are commits on ``branch`` that are not
     reachable from ``base``.
     """
+    validate_ref_name(branch)
+    validate_ref_name(base)
     _rc, stdout, _stderr = await run_git(
         ["rev-list", "--count", f"{base}..{branch}"],
         cwd=repo_path,
@@ -176,6 +206,8 @@ async def get_changed_files(
     base: str,
 ) -> list[str]:
     """Return list of files changed between base and branch."""
+    validate_ref_name(branch)
+    validate_ref_name(base)
     _rc, stdout, _stderr = await run_git(
         ["diff", "--name-only", base, branch],
         cwd=repo_path,
@@ -192,8 +224,9 @@ async def merge_fast_forward(
     Raises:
         IntegrationError: If fast-forward is not possible.
     """
+    validate_ref_name(branch)
     returncode, _stdout, stderr = await run_git(
-        ["merge", "--ff-only", branch],
+        ["merge", "--ff-only", "--", branch],
         cwd=repo_path,
         check=False,
     )
@@ -223,10 +256,11 @@ async def merge_commit(
     Raises:
         IntegrationError: If the merge fails (conflicts).
     """
+    validate_ref_name(branch)
     cmd = ["merge", "--no-edit"]
     if strategy_option:
         cmd.extend(["-X", strategy_option])
-    cmd.append(branch)
+    cmd.extend(["--", branch])
 
     returncode, stdout, stderr = await run_git(
         cmd,
@@ -254,6 +288,8 @@ async def rebase_onto(
     Raises:
         IntegrationError: If rebase fails (conflicts).
     """
+    validate_ref_name(branch)
+    validate_ref_name(onto)
     returncode, stdout, stderr = await run_git(
         ["rebase", onto, branch],
         cwd=repo_path,
@@ -279,8 +315,9 @@ async def local_branch_exists(repo_root: Path, branch: str) -> bool:
 
     Requirements: 19-REQ-1.1
     """
+    validate_ref_name(branch)
     _rc, stdout, _stderr = await run_git(
-        ["branch", "--list", branch],
+        ["branch", "--list", "--", branch],
         cwd=repo_root,
         check=False,
     )
@@ -296,6 +333,7 @@ async def remote_branch_exists(
 
     Requirements: 19-REQ-1.1
     """
+    validate_ref_name(branch)
     _rc, stdout, _stderr = await run_git(
         ["ls-remote", "--heads", remote, branch],
         cwd=repo_root,
@@ -349,6 +387,7 @@ async def push_to_remote(
 
     Requirements: 19-REQ-3.1
     """
+    validate_ref_name(branch)
     rc, _stdout, stderr = await run_git(
         ["push", remote, branch],
         cwd=repo_root,

--- a/agent_fox/workspace/harvest.py
+++ b/agent_fox/workspace/harvest.py
@@ -205,7 +205,7 @@ async def _harvest_under_lock(
         # failure). We need conflicts to remain so the merge agent can
         # resolve them.
         merge_rc, merge_stdout, merge_stderr = await run_git(
-            ["merge", "--no-edit", workspace.branch],
+            ["merge", "--no-edit", "--", workspace.branch],
             cwd=repo_root,
             check=False,
         )

--- a/tests/unit/workspace/test_git_ref_validation.py
+++ b/tests/unit/workspace/test_git_ref_validation.py
@@ -1,0 +1,91 @@
+"""Tests for git ref name validation.
+
+Regression tests for GitHub issue #189: Git argument injection via
+unvalidated branch/ref names.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_fox.core.errors import WorkspaceError
+from agent_fox.workspace.git import validate_ref_name
+
+
+class TestValidateRefNameRejectsInvalid:
+    """Ref names that could cause argument injection are rejected."""
+
+    def test_rejects_leading_dash(self) -> None:
+        """Branch names starting with '-' are rejected."""
+        with pytest.raises(WorkspaceError, match="Invalid git ref name"):
+            validate_ref_name("--strategy=ours")
+
+    def test_rejects_single_dash(self) -> None:
+        with pytest.raises(WorkspaceError, match="Invalid git ref name"):
+            validate_ref_name("-x")
+
+    def test_rejects_double_dash_flag(self) -> None:
+        with pytest.raises(WorkspaceError, match="Invalid git ref name"):
+            validate_ref_name("--allow-unrelated-histories")
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(WorkspaceError, match="Invalid git ref name"):
+            validate_ref_name("")
+
+    def test_rejects_space(self) -> None:
+        with pytest.raises(WorkspaceError, match="Invalid git ref name"):
+            validate_ref_name("my branch")
+
+    def test_rejects_colon(self) -> None:
+        with pytest.raises(WorkspaceError, match="Invalid git ref name"):
+            validate_ref_name("refs:heads")
+
+    def test_rejects_tilde(self) -> None:
+        with pytest.raises(WorkspaceError, match="Invalid git ref name"):
+            validate_ref_name("branch~1")
+
+    def test_rejects_caret(self) -> None:
+        with pytest.raises(WorkspaceError, match="Invalid git ref name"):
+            validate_ref_name("branch^2")
+
+    def test_rejects_double_dot(self) -> None:
+        with pytest.raises(WorkspaceError, match="Invalid git ref name"):
+            validate_ref_name("main..develop")
+
+    def test_rejects_backslash(self) -> None:
+        with pytest.raises(WorkspaceError, match="Invalid git ref name"):
+            validate_ref_name("path\\branch")
+
+    def test_rejects_at_brace(self) -> None:
+        with pytest.raises(WorkspaceError, match="Invalid git ref name"):
+            validate_ref_name("branch@{upstream}")
+
+
+class TestValidateRefNameAcceptsValid:
+    """Valid git ref names are accepted without error."""
+
+    def test_simple_name(self) -> None:
+        validate_ref_name("main")
+
+    def test_feature_branch(self) -> None:
+        validate_ref_name("feature/my-feature")
+
+    def test_with_dots(self) -> None:
+        validate_ref_name("release/v2.5.0")
+
+    def test_with_underscores(self) -> None:
+        validate_ref_name("feature/my_feature_branch")
+
+    def test_worktree_branch(self) -> None:
+        validate_ref_name("feature/03_session/1")
+
+    def test_origin_prefix(self) -> None:
+        validate_ref_name("origin/develop")
+
+    def test_returns_name(self) -> None:
+        """validate_ref_name returns the validated name for chaining."""
+        assert validate_ref_name("develop") == "develop"
+
+    def test_at_sign_without_brace(self) -> None:
+        """@ alone (without {) is valid in git ref names."""
+        validate_ref_name("user@branch")


### PR DESCRIPTION
## Summary

Add centralized `validate_ref_name()` to prevent git argument injection via branch/ref names starting with `-`. Applied validation to all 11 git wrapper functions and added `--` end-of-options separators where git supports them.

Closes #189

## Changes

| File | Change |
|------|--------|
| `agent_fox/workspace/git.py` | Added `validate_ref_name()` with safe ref pattern; applied to all 11 functions; added `--` separators |
| `agent_fox/workspace/__init__.py` | Exported `validate_ref_name` |
| `agent_fox/workspace/harvest.py` | Added `--` separator to direct merge call |
| `tests/unit/workspace/test_git_ref_validation.py` | 19 regression tests |

## Tests

- `test_git_ref_validation.py`: 11 rejection tests (leading dash, empty, spaces, colons, tildes, carets, double-dots, backslash, @{) + 8 acceptance tests

## Verification

- All existing tests pass: ✅ (2611 existing)
- New tests pass: ✅ (19 added)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*