### PR TITLE
fix(platform): add __repr__ to GitHubPlatform to prevent token leakage (fixes #187)

### DIFF
--- a/agent_fox/platform/github.py
+++ b/agent_fox/platform/github.py
@@ -57,6 +57,9 @@ class GitHubPlatform:
         self._repo = repo
         self._token = token
 
+    def __repr__(self) -> str:
+        return f"GitHubPlatform(owner={self._owner!r}, repo={self._repo!r})"
+
     async def create_pr(
         self,
         branch: str,

--- a/tests/unit/platform/test_github_rest.py
+++ b/tests/unit/platform/test_github_rest.py
@@ -260,3 +260,30 @@ class TestErrorResponseTruncation:
         with patch(target, return_value=mock_client):
             with pytest.raises(IntegrationError, match="Short error"):
                 await platform.create_pr("feature/test", "Test", "Body")
+
+
+# ---------------------------------------------------------------------------
+# Regression test for issue #187: token must not leak in repr/str
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubPlatformRepr:
+    """Token must not appear in repr or str output.
+
+    Regression test for issue #187: GitHub PAT stored as plain instance
+    attribute may leak in tracebacks.
+    """
+
+    def test_repr_excludes_token(self) -> None:
+        """repr() must not contain the token value."""
+        platform = GitHubPlatform(owner="acme", repo="widgets", token="ghp_s3cret")
+        result = repr(platform)
+        assert "ghp_s3cret" not in result
+        assert "acme" in result
+        assert "widgets" in result
+
+    def test_str_excludes_token(self) -> None:
+        """str() must not contain the token value."""
+        platform = GitHubPlatform(owner="acme", repo="widgets", token="ghp_s3cret")
+        result = str(platform)
+        assert "ghp_s3cret" not in result


### PR DESCRIPTION
## Summary

Adds `__repr__` to `GitHubPlatform` that excludes the `_token` attribute, preventing accidental PAT exposure in tracebacks, debug logs, and crash dumps.

Closes #187

## Changes

| File | Change |
|------|--------|
| `agent_fox/platform/github.py` | Add `__repr__` method showing only `owner` and `repo` |
| `tests/unit/platform/test_github_rest.py` | Add `TestGitHubPlatformRepr` with 2 regression tests |

## Tests

- `test_repr_excludes_token` — verifies `repr()` does not contain the token
- `test_str_excludes_token` — verifies `str()` does not contain the token

## Verification

- All existing tests pass: ✅ (2632 passed)
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*