### PR TITLE
fix(knowledge): validate table names against allowlist before SQL interpolation (fixes #188)

### DIFF
--- a/agent_fox/knowledge/causal.py
+++ b/agent_fox/knowledge/causal.py
@@ -207,6 +207,9 @@ def _query_findings_for_spec(
     Generic helper that replaces the three per-table query functions.
     Each row is unpacked positionally into *cls*.
     """
+    from agent_fox.knowledge.review_store import _validate_table_name
+
+    _validate_table_name(table)
     try:
         rows = conn.execute(
             f"SELECT {columns} FROM {table} "  # noqa: S608

--- a/agent_fox/knowledge/review_store.py
+++ b/agent_fox/knowledge/review_store.py
@@ -21,6 +21,20 @@ logger = logging.getLogger(__name__)
 VALID_SEVERITIES = {"critical", "major", "minor", "observation"}
 VALID_VERDICTS = {"PASS", "FAIL"}
 
+# Defense-in-depth: only these table names may be interpolated into SQL.
+_ALLOWED_TABLES: frozenset[str] = frozenset(
+    {"review_findings", "drift_findings", "verification_results"}
+)
+
+
+def _validate_table_name(table: str) -> None:
+    """Raise ValueError if *table* is not in the allowlist."""
+    if table not in _ALLOWED_TABLES:
+        raise ValueError(
+            f"Table {table!r} is not in the allowed set: {sorted(_ALLOWED_TABLES)}"
+        )
+
+
 _SEVERITY_ORDER = {"critical": 0, "major": 1, "minor": 2, "observation": 3}
 
 
@@ -119,6 +133,7 @@ def _supersede_active_records(
     marker: str,
 ) -> list[str]:
     """Mark active records as superseded. Returns list of superseded IDs."""
+    _validate_table_name(table)
     existing = conn.execute(
         f"SELECT id::VARCHAR FROM {table} "  # noqa: S608
         "WHERE spec_name = ? AND task_group = ? AND superseded_by IS NULL",
@@ -164,6 +179,7 @@ def _insert_with_supersession(
 
     Shared logic for insert_findings and insert_verdicts.
     """
+    _validate_table_name(table)
     if not records:
         return 0
 

--- a/tests/unit/knowledge/test_review_store.py
+++ b/tests/unit/knowledge/test_review_store.py
@@ -322,3 +322,47 @@ class TestQueryBySession:
         results = query_verdicts_by_session(schema_conn, "s1")
         assert len(results) == 1
         assert results[0].requirement_id == "27-REQ-1.1"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #188: table name allowlist validation
+# ---------------------------------------------------------------------------
+
+
+class TestTableNameValidation:
+    """Validate that SQL helper functions reject disallowed table names."""
+
+    def test_validate_table_name_accepts_allowed(self) -> None:
+        from agent_fox.knowledge.review_store import _validate_table_name
+
+        for name in ("review_findings", "drift_findings", "verification_results"):
+            _validate_table_name(name)  # should not raise
+
+    def test_validate_table_name_rejects_unknown(self) -> None:
+        from agent_fox.knowledge.review_store import _validate_table_name
+
+        with pytest.raises(ValueError, match="not in the allowed set"):
+            _validate_table_name("users; DROP TABLE --")
+
+    def test_supersede_rejects_bad_table(
+        self, schema_conn: duckdb.DuckDBPyConnection
+    ) -> None:
+        from agent_fox.knowledge.review_store import _supersede_active_records
+
+        with pytest.raises(ValueError, match="not in the allowed set"):
+            _supersede_active_records(schema_conn, "evil_table", "spec", "1", "marker")
+
+    def test_insert_with_supersession_rejects_bad_table(
+        self, schema_conn: duckdb.DuckDBPyConnection
+    ) -> None:
+        from agent_fox.knowledge.review_store import _insert_with_supersession
+
+        with pytest.raises(ValueError, match="not in the allowed set"):
+            _insert_with_supersession(
+                schema_conn,
+                table="evil_table",
+                columns="id",
+                records=[],
+                value_extractor=lambda r: [],
+                record_type_label="test",
+            )


### PR DESCRIPTION
## Summary

Adds defense-in-depth SQL injection prevention by validating table names against an explicit allowlist before f-string interpolation in DuckDB queries. All three functions that interpolate table names (`_query_findings_for_spec`, `_supersede_active_records`, `_insert_with_supersession`) now call `_validate_table_name()` which raises `ValueError` for unrecognized table names.

Closes #188

## Changes

| File | Change |
|------|--------|
| `agent_fox/knowledge/review_store.py` | Add `_ALLOWED_TABLES` frozenset and `_validate_table_name()`; call in `_supersede_active_records` and `_insert_with_supersession` |
| `agent_fox/knowledge/causal.py` | Call `_validate_table_name()` in `_query_findings_for_spec` |
| `tests/unit/knowledge/test_review_store.py` | Add `TestTableNameValidation` with 4 regression tests |

## Tests

- `test_validate_table_name_accepts_allowed` — all three valid table names accepted
- `test_validate_table_name_rejects_unknown` — injection attempt raises ValueError
- `test_supersede_rejects_bad_table` — rejects bad table in supersede path
- `test_insert_with_supersession_rejects_bad_table` — rejects bad table in insert path

## Verification

- All existing tests pass: ✅ (2654 passed)
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*