### PR TITLE
fix(knowledge): escape markdown special characters in rendered output (fixes #193)

### DIFF
--- a/agent_fox/knowledge/query.py
+++ b/agent_fox/knowledge/query.py
@@ -29,6 +29,32 @@ from agent_fox.knowledge.embeddings import EmbeddingGenerator
 from agent_fox.knowledge.search import SearchResult, VectorSearch
 
 # ---------------------------------------------------------------------------
+# Shared text-sanitisation helpers
+# ---------------------------------------------------------------------------
+
+# Matches ANSI escape sequences (SGR and other CSI sequences).
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]?")
+
+# Characters that have special meaning in CommonMark.
+_MD_SPECIAL_RE = re.compile(r"([\\`*_\{\}\[\]()#+\-.!~|>])")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from text."""
+    return _ANSI_RE.sub("", text)
+
+
+def _escape_markdown(text: str) -> str:
+    """Backslash-escape markdown special characters.
+
+    Prevents database-stored content from being interpreted as
+    markdown formatting when output is piped to a markdown renderer.
+    Issue #193.
+    """
+    return _MD_SPECIAL_RE.sub(r"\\\1", text)
+
+
+# ---------------------------------------------------------------------------
 # Oracle (merged from oracle.py)
 # ---------------------------------------------------------------------------
 
@@ -362,10 +388,15 @@ def render_patterns(patterns: list[Pattern], *, use_color: bool = True) -> str:
 
     lines: list[str] = []
     for p in patterns:
+        # Issue #193: escape markdown special characters in
+        # database-sourced fields.
+        trigger = _escape_markdown(p.trigger)
+        effect = _escape_markdown(p.effect)
+        last_seen = _escape_markdown(p.last_seen)
         line = (
-            f"{p.trigger} -> {p.effect} "
+            f"{trigger} -> {effect} "
             f"({p.occurrences} occurrences, "
-            f"last seen {p.last_seen}, "
+            f"last seen {last_seen}, "
             f"confidence {p.confidence})"
         )
         lines.append(line)
@@ -378,13 +409,6 @@ def render_patterns(patterns: list[Pattern], *, use_color: bool = True) -> str:
 # ---------------------------------------------------------------------------
 
 _temporal_logger = logging.getLogger("agent_fox.knowledge.temporal")
-
-_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]?")
-
-
-def _strip_ansi(text: str) -> str:
-    """Remove ANSI escape codes from text."""
-    return _ANSI_RE.sub("", text)
 
 
 @dataclass(frozen=True)
@@ -432,11 +456,12 @@ class Timeline:
 
             # 13-REQ-6.3: always emit plain text (strip any ANSI
             # escapes that may be embedded in stored data).
-            content = _strip_ansi(node.content)
-            ts = _strip_ansi(node.timestamp or "unknown")
-            spec = _strip_ansi(node.spec_name or "n/a")
-            session = _strip_ansi(node.session_id or "n/a")
-            commit = _strip_ansi(node.commit_sha or "n/a")
+            # Issue #193: escape markdown special characters.
+            content = _escape_markdown(_strip_ansi(node.content))
+            ts = _escape_markdown(_strip_ansi(node.timestamp or "unknown"))
+            spec = _escape_markdown(_strip_ansi(node.spec_name or "n/a"))
+            session = _escape_markdown(_strip_ansi(node.session_id or "n/a"))
+            commit = _escape_markdown(_strip_ansi(node.commit_sha or "n/a"))
 
             line_1 = f"{indent}{connector}{content}"
             line_2 = f"{indent}   [{ts}] spec:{spec} session:{session} commit:{commit}"

--- a/tests/unit/knowledge/test_patterns.py
+++ b/tests/unit/knowledge/test_patterns.py
@@ -84,6 +84,21 @@ class TestRenderPatterns:
         assert "3" in text
         assert "\x1b[" not in text
 
+    def test_escapes_markdown_special_chars(self) -> None:
+        """Issue #193: markdown special characters are backslash-escaped."""
+        patterns = [
+            Pattern(
+                trigger="src/[auth]/",
+                effect="test_*.py failures",
+                occurrences=3,
+                last_seen="2026-01-05",
+                confidence=0.7,
+            ),
+        ]
+        text = render_patterns(patterns, use_color=False)
+        assert "src/\\[auth\\]/" in text
+        assert "test\\_\\*\\.py failures" in text
+
     def test_render_empty_patterns(self) -> None:
         """Rendering an empty pattern list produces output without errors."""
         text = render_patterns([], use_color=False)

--- a/tests/unit/knowledge/test_temporal.py
+++ b/tests/unit/knowledge/test_temporal.py
@@ -48,10 +48,11 @@ class TestTimelineRendering:
         tl = Timeline(nodes=nodes, query="test")
         text = tl.render(use_color=False)
 
-        assert "** User.email changed to nullable" in text
-        assert "  -> test_user_model.py assertions failed" in text
-        assert "[2025-11-03T14:22:00]" in text
-        assert "spec:07_oauth" in text
+        # Issue #193: markdown special chars are escaped with backslash
+        assert "** User\\.email changed to nullable" in text
+        assert "  -> test\\_user\\_model\\.py assertions failed" in text
+        assert "[2025\\-11\\-03T14:22:00]" in text
+        assert "spec:07\\_oauth" in text
         assert "commit:a1b2c3d" in text
 
     def test_depth_controls_indentation(self) -> None:
@@ -92,6 +93,25 @@ class TestTimelineRendering:
         tl = Timeline(nodes=[], query="test")
         text = tl.render()
         assert "No causal timeline" in text
+
+    def test_escapes_markdown_special_chars(self) -> None:
+        """Issue #193: markdown special characters are backslash-escaped."""
+        node = TimelineNode(
+            fact_id="x",
+            content="Fix [bug] in *auth* module (v2.0)",
+            spec_name="spec_name",
+            session_id="s/1",
+            commit_sha=None,
+            timestamp="2025-01-01",
+            relationship="root",
+            depth=0,
+        )
+        tl = Timeline(nodes=[node], query="test")
+        text = tl.render(use_color=False)
+        # Brackets, asterisks, parens should be escaped
+        assert "\\[bug\\]" in text
+        assert "\\*auth\\*" in text
+        assert "\\(v2\\.0\\)" in text
 
     def test_missing_provenance_shows_na(self) -> None:
         """Missing provenance fields show n/a."""


### PR DESCRIPTION
## Summary

Escape CommonMark special characters in database-sourced content rendered by `Timeline.render()` and `render_patterns()` to prevent unexpected formatting when output is piped to a markdown renderer.

Closes #193

## Changes

| File | Change |
|------|--------|
| `agent_fox/knowledge/query.py` | Added `_escape_markdown()` helper; applied to all DB-sourced fields in `Timeline.render()` and `render_patterns()` |
| `tests/unit/knowledge/test_temporal.py` | Updated assertion + added markdown escaping test |
| `tests/unit/knowledge/test_patterns.py` | Added markdown escaping test |

## Verification

- All existing tests pass: ✅ (2693 passed)
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*