### PR TITLE
fix(workspace,platform): sanitize error messages to prevent info leakage (fixes #192)

### DIFF
--- a/agent_fox/platform/github.py
+++ b/agent_fox/platform/github.py
@@ -97,8 +97,9 @@ class GitHubPlatform:
             logger.info("Created PR: %s", pr_url)
             return pr_url
         detail = _truncate_response(resp.text)
+        logger.debug("PR creation response (%d): %s", resp.status_code, detail)
         raise IntegrationError(
-            f"GitHub PR creation failed ({resp.status_code}): {detail}",
+            f"GitHub PR creation failed ({resp.status_code})",
             branch=branch,
         )
 
@@ -149,8 +150,9 @@ class GitHubPlatform:
             resp = await client.get(url, params={"q": q}, headers=headers)
         if resp.status_code != 200:
             detail = _truncate_response(resp.text)
+            logger.debug("Issue search response (%d): %s", resp.status_code, detail)
             raise IntegrationError(
-                f"GitHub issue search failed ({resp.status_code}): {detail}",
+                f"GitHub issue search failed ({resp.status_code})",
             )
         items = resp.json().get("items", [])
         results = [
@@ -188,8 +190,9 @@ class GitHubPlatform:
             resp = await client.post(url, json=payload, headers=headers)
         if resp.status_code != 201:
             detail = _truncate_response(resp.text)
+            logger.debug("Issue creation response (%d): %s", resp.status_code, detail)
             raise IntegrationError(
-                f"GitHub issue creation failed ({resp.status_code}): {detail}",
+                f"GitHub issue creation failed ({resp.status_code})",
             )
         data = resp.json()
         result = IssueResult(
@@ -219,8 +222,9 @@ class GitHubPlatform:
             resp = await client.patch(url, json=payload, headers=headers)
         if resp.status_code != 200:
             detail = _truncate_response(resp.text)
+            logger.debug("Issue update response (%d): %s", resp.status_code, detail)
             raise IntegrationError(
-                f"GitHub issue update failed ({resp.status_code}): {detail}",
+                f"GitHub issue update failed ({resp.status_code})",
             )
         logger.info("Updated issue #%d", issue_number)
 
@@ -246,8 +250,9 @@ class GitHubPlatform:
             resp = await client.post(url, json=payload, headers=headers)
         if resp.status_code != 201:
             detail = _truncate_response(resp.text)
+            logger.debug("Issue comment response (%d): %s", resp.status_code, detail)
             raise IntegrationError(
-                f"GitHub issue comment failed ({resp.status_code}): {detail}",
+                f"GitHub issue comment failed ({resp.status_code})",
             )
         logger.info("Added comment to issue #%d", issue_number)
 
@@ -275,8 +280,9 @@ class GitHubPlatform:
             resp = await client.patch(url, json=payload, headers=headers)
         if resp.status_code != 200:
             detail = _truncate_response(resp.text)
+            logger.debug("Issue close response (%d): %s", resp.status_code, detail)
             raise IntegrationError(
-                f"GitHub issue close failed ({resp.status_code}): {detail}",
+                f"GitHub issue close failed ({resp.status_code})",
             )
         logger.info("Closed issue #%d", issue_number)
 

--- a/agent_fox/workspace/git.py
+++ b/agent_fox/workspace/git.py
@@ -97,11 +97,12 @@ async def run_git(
         proc.kill()
         await proc.wait()
         cmd_str = " ".join(["git", *args])
-        msg = f"git command timed out after {timeout}s: {cmd_str}"
-        logger.error(msg)
+        subcommand = args[0] if args else "unknown"
+        logger.error("git %s timed out after %ds: %s", subcommand, timeout, cmd_str)
+        sanitized_msg = f"git {subcommand} timed out after {timeout}s"
         if check:
-            raise WorkspaceError(msg, command=cmd_str, returncode=-1)
-        return -1, "", msg
+            raise WorkspaceError(sanitized_msg, command=cmd_str, returncode=-1)
+        return -1, "", sanitized_msg
 
     stdout = stdout_bytes.decode()
     stderr = stderr_bytes.decode()
@@ -109,8 +110,12 @@ async def run_git(
 
     if check and returncode != 0:
         cmd_str = " ".join(["git", *args])
+        subcommand = args[0] if args else "unknown"
+        logger.debug(
+            "git %s failed (rc=%d): %s", subcommand, returncode, stderr.strip()
+        )
         raise WorkspaceError(
-            f"git command failed: {cmd_str}\n{stderr.strip()}",
+            f"git {subcommand} failed (exit code {returncode})",
             command=cmd_str,
             returncode=returncode,
         )

--- a/tests/unit/platform/test_github_rest.py
+++ b/tests/unit/platform/test_github_rest.py
@@ -207,11 +207,16 @@ class TestParseGithubRemoteNonGithub:
 # ---------------------------------------------------------------------------
 
 
-class TestErrorResponseTruncation:
-    """H3: GitHub API error responses are truncated in exception messages."""
+class TestErrorResponseSanitization:
+    """H3: GitHub API error responses are not leaked in exception messages.
 
-    async def test_long_error_text_is_truncated(self) -> None:
-        """Error text longer than 500 chars is truncated in the exception."""
+    Regression test for issue #192: error messages must not expose raw API
+    response bodies. Status codes are retained for debugging, but response
+    text is logged at debug level only.
+    """
+
+    async def test_api_response_not_in_exception(self) -> None:
+        """Raw API response text must not appear in the exception message."""
         platform = GitHubPlatform(owner="o", repo="r", token="tok")
 
         mock_response_repo = MagicMock()
@@ -220,7 +225,7 @@ class TestErrorResponseTruncation:
 
         mock_response_pr = MagicMock()
         mock_response_pr.status_code = 422
-        mock_response_pr.text = "x" * 1000  # 1000-char response
+        mock_response_pr.text = "Detailed internal error with /secret/path info"
 
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value=mock_response_repo)
@@ -233,13 +238,12 @@ class TestErrorResponseTruncation:
             with pytest.raises(IntegrationError) as exc_info:
                 await platform.create_pr("feature/test", "Test", "Body")
 
-        # The error message should NOT contain the full 1000 chars
         error_msg = str(exc_info.value)
-        assert len(error_msg) < 700  # reasonable bound with prefix text
-        assert "..." in error_msg  # truncation marker
+        assert "422" in error_msg  # status code is retained
+        assert "/secret/path" not in error_msg  # raw response is not leaked
 
-    async def test_short_error_text_not_truncated(self) -> None:
-        """Error text shorter than 500 chars is preserved as-is."""
+    async def test_status_code_in_exception(self) -> None:
+        """Exception message includes the HTTP status code."""
         platform = GitHubPlatform(owner="o", repo="r", token="tok")
 
         mock_response_repo = MagicMock()
@@ -258,7 +262,7 @@ class TestErrorResponseTruncation:
 
         target = "agent_fox.platform.github.httpx.AsyncClient"
         with patch(target, return_value=mock_client):
-            with pytest.raises(IntegrationError, match="Short error"):
+            with pytest.raises(IntegrationError, match="422"):
                 await platform.create_pr("feature/test", "Test", "Body")
 
 


### PR DESCRIPTION
## Summary

Sanitizes error messages in `git.py` and `github.py` to prevent leaking internal paths, stderr output, and API response details in exception messages. Full diagnostic information is logged at debug level, while exception messages contain only the operation name and status/exit code.

Closes #192

## Changes

| File | Change |
|------|--------|
| `agent_fox/workspace/git.py` | Log stderr at debug; raise with sanitized message (subcommand + exit code only) |
| `agent_fox/platform/github.py` | Log API response at debug; raise with status code only |
| `tests/unit/platform/test_github_rest.py` | Update tests to verify response text is not leaked in exceptions |

## Tests

- `test_api_response_not_in_exception` — raw API response not in exception message
- `test_status_code_in_exception` — status code retained in exception message

## Verification

- All existing tests pass: ✅ (2693 passed)
- New/updated tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*