### PR TITLE
fix(retry): retry on network-level transport errors (fixes #208)

### DIFF
--- a/agent_fox/core/retry.py
+++ b/agent_fox/core/retry.py
@@ -1,7 +1,8 @@
 """Retry helpers for Anthropic API calls with fixed backoff schedule.
 
-Retries on RateLimitError (429) and server errors (5xx) using a fixed
-delay schedule of 2s → 30s → 60s, then aborts.
+Retries on RateLimitError (429), server errors (5xx), and network-level
+transport errors (OSError family) using a fixed delay schedule of
+2s → 30s → 60s, then aborts.
 """
 
 import asyncio
@@ -22,6 +23,8 @@ def _is_retryable(exc: Exception) -> bool:
     if isinstance(exc, RateLimitError):
         return True
     if isinstance(exc, APIStatusError) and exc.status_code >= 500:
+        return True
+    if isinstance(exc, OSError):
         return True
     return False
 
@@ -47,7 +50,7 @@ async def retry_api_call_async[T](
     for attempt in range(max_attempts):
         try:
             return await fn()
-        except (RateLimitError, APIStatusError) as exc:
+        except (RateLimitError, APIStatusError, OSError) as exc:
             if not _is_retryable(exc) or attempt == max_attempts - 1:
                 raise
             delay = _RETRY_DELAYS[attempt]
@@ -73,7 +76,7 @@ def retry_api_call[T](
     for attempt in range(max_attempts):
         try:
             return fn()
-        except (RateLimitError, APIStatusError) as exc:
+        except (RateLimitError, APIStatusError, OSError) as exc:
             if not _is_retryable(exc) or attempt == max_attempts - 1:
                 raise
             delay = _RETRY_DELAYS[attempt]

--- a/tests/unit/core/test_retry.py
+++ b/tests/unit/core/test_retry.py
@@ -104,6 +104,63 @@ class TestRetryApiCallAsync:
         assert fn.call_count == 1
 
 
+class TestRetryApiCallAsyncNetworkErrors:
+    """Verify that network-level transport errors trigger retries."""
+
+    @pytest.mark.asyncio
+    async def test_retries_on_oserror_then_succeeds(self) -> None:
+        exc = OSError(50, "Network is down")
+        fn = AsyncMock(side_effect=[exc, "ok"])
+
+        with patch("agent_fox.core.retry.asyncio.sleep", new_callable=AsyncMock):
+            result = await retry_api_call_async(fn, context="test")
+
+        assert result == "ok"
+        assert fn.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retries_on_connection_error_then_succeeds(self) -> None:
+        exc = ConnectionError("Connection refused")
+        fn = AsyncMock(side_effect=[exc, "ok"])
+
+        with patch("agent_fox.core.retry.asyncio.sleep", new_callable=AsyncMock):
+            result = await retry_api_call_async(fn, context="test")
+
+        assert result == "ok"
+        assert fn.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retries_on_timeout_error_then_succeeds(self) -> None:
+        exc = TimeoutError("Connection timed out")
+        fn = AsyncMock(side_effect=[exc, "ok"])
+
+        with patch("agent_fox.core.retry.asyncio.sleep", new_callable=AsyncMock):
+            result = await retry_api_call_async(fn, context="test")
+
+        assert result == "ok"
+        assert fn.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_raises_oserror_after_all_retries_exhausted(self) -> None:
+        exc = OSError(50, "Network is down")
+        fn = AsyncMock(side_effect=exc)
+
+        with patch("agent_fox.core.retry.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(OSError):
+                await retry_api_call_async(fn, context="test")
+
+        assert fn.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_non_retryable_exception(self) -> None:
+        fn = AsyncMock(side_effect=ValueError("bad value"))
+
+        with pytest.raises(ValueError):
+            await retry_api_call_async(fn, context="test")
+
+        assert fn.call_count == 1
+
+
 class TestRetryApiCallSync:
     def test_succeeds_without_retry(self) -> None:
         fn = MagicMock(return_value="ok")
@@ -137,6 +194,48 @@ class TestRetryApiCallSync:
         fn = MagicMock(side_effect=exc)
 
         with pytest.raises(APIStatusError):
+            retry_api_call(fn, context="test")
+
+        assert fn.call_count == 1
+
+
+class TestRetryApiCallSyncNetworkErrors:
+    """Verify sync retry handles network-level transport errors."""
+
+    def test_retries_on_oserror_then_succeeds(self) -> None:
+        exc = OSError(50, "Network is down")
+        fn = MagicMock(side_effect=[exc, "ok"])
+
+        with patch("agent_fox.core.retry.time.sleep"):
+            result = retry_api_call(fn, context="test")
+
+        assert result == "ok"
+        assert fn.call_count == 2
+
+    def test_retries_on_connection_error_then_succeeds(self) -> None:
+        exc = ConnectionError("Connection refused")
+        fn = MagicMock(side_effect=[exc, "ok"])
+
+        with patch("agent_fox.core.retry.time.sleep"):
+            result = retry_api_call(fn, context="test")
+
+        assert result == "ok"
+        assert fn.call_count == 2
+
+    def test_raises_oserror_after_all_retries_exhausted(self) -> None:
+        exc = OSError(50, "Network is down")
+        fn = MagicMock(side_effect=exc)
+
+        with patch("agent_fox.core.retry.time.sleep"):
+            with pytest.raises(OSError):
+                retry_api_call(fn, context="test")
+
+        assert fn.call_count == 4
+
+    def test_does_not_retry_non_retryable_exception(self) -> None:
+        fn = MagicMock(side_effect=ValueError("bad value"))
+
+        with pytest.raises(ValueError):
             retry_api_call(fn, context="test")
 
         assert fn.call_count == 1


### PR DESCRIPTION
## Summary

Add `OSError` to the retryable exception set in `retry_api_call` and `retry_api_call_async`, so that transient network errors (connection refused, network down, timeouts) are retried instead of propagating immediately. This fixes the Vertex AI OAuth2 token refresh failure path described in #208.

Closes #208

## Changes

| File | Change |
|------|--------|
| `agent_fox/core/retry.py` | Added `OSError` to `_is_retryable` predicate and both `except` clauses |
| `tests/unit/core/test_retry.py` | Added 9 tests for network error retry behavior (async + sync) |

## Tests

- `TestRetryApiCallAsyncNetworkErrors`: OSError, ConnectionError, TimeoutError retries; exhaustion; non-retryable propagation
- `TestRetryApiCallSyncNetworkErrors`: OSError, ConnectionError retries; exhaustion; non-retryable propagation

## Verification

- All existing tests pass: ✅
- New tests pass: ✅ (20/20 in test_retry.py)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*