### PR TITLE
feat(config): add unified per-archetype config via [archetypes.overrides.*] (fixes #207)

### DIFF
--- a/.agent-fox/config.toml
+++ b/.agent-fox/config.toml
@@ -64,6 +64,35 @@ auditor = true
 # max_turns = {}
 ## Per-archetype extended thinking configuration (default: {})
 # thinking = {}
+## Unified per-archetype configuration tables (see [archetypes.overrides.*] below)
+# overrides = {}
+
+# ---------------------------------------------------------------------------
+# Unified per-archetype overrides (preferred over the legacy dicts above)
+# Each [archetypes.overrides.<name>] block supports:
+#   model_tier     — "SIMPLE" | "STANDARD" | "ADVANCED"  (None = registry default)
+#   max_turns      — integer >= 0, 0 = unlimited           (None = registry default)
+#   thinking_mode  — "enabled" | "adaptive" | "disabled"  (None = registry default)
+#   thinking_budget — integer >= 0 (tokens)               (None = registry default)
+#   allowlist      — list of allowed bash commands         (None = registry default)
+# ---------------------------------------------------------------------------
+
+# Example: run the coder on the ADVANCED model with extra turns
+# [archetypes.overrides.coder]
+# model_tier = "ADVANCED"
+# max_turns = 200
+# thinking_mode = "adaptive"
+
+# Example: use STANDARD model for skeptic reviews (cost reduction)
+# [archetypes.overrides.skeptic]
+# model_tier = "STANDARD"
+# max_turns = 50
+
+# Example: restrict verifier to a minimal allowlist
+# [archetypes.overrides.verifier]
+# model_tier = "ADVANCED"
+# max_turns = 75
+# allowlist = ["ls", "cat", "git", "make", "uv"]
 
 # [archetypes.skeptic_settings]
 ## Finding count to block merge (>=0, default: 3)

--- a/agent_fox/core/config.py
+++ b/agent_fox/core/config.py
@@ -280,6 +280,50 @@ class ThinkingConfig(BaseModel):
         return self
 
 
+class PerArchetypeConfig(BaseModel):
+    """Unified per-archetype configuration table.
+
+    Used via ``[archetypes.overrides.<name>]`` in config.toml. Provides a
+    single, consolidated surface for all per-archetype knobs that previously
+    required separate dict fields (``models``, ``max_turns``, ``thinking``,
+    ``allowlists``).
+
+    Requirements: 207-REQ-1, 207-REQ-2, 207-REQ-3
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    model_tier: str | None = Field(
+        default=None,
+        description="Model tier override (SIMPLE, STANDARD, ADVANCED). None = use registry default.",
+    )
+    max_turns: int | None = Field(
+        default=None,
+        description="Max turns override. 0 = unlimited. None = use registry default.",
+        ge=0,
+    )
+    thinking_mode: Literal["enabled", "adaptive", "disabled"] | None = Field(
+        default=None,
+        description="Extended thinking mode. None = use registry default.",
+    )
+    thinking_budget: int | None = Field(
+        default=None,
+        description="Extended thinking budget tokens. None = use registry default.",
+        ge=0,
+    )
+    allowlist: list[str] | None = Field(
+        default=None,
+        description="Bash command allowlist override. None = use registry default.",
+    )
+
+    @model_validator(mode="after")
+    def validate_thinking(self) -> Self:
+        """thinking_budget must be > 0 when thinking_mode is 'enabled'."""
+        if self.thinking_mode == "enabled" and self.thinking_budget is not None and self.thinking_budget <= 0:
+            raise ValueError("thinking_budget must be > 0 when thinking_mode is 'enabled'")
+        return self
+
+
 class ArchetypeInstancesConfig(BaseModel):
     """Per-archetype instance count configuration.
 
@@ -384,6 +428,14 @@ class ArchetypesConfig(BaseModel):
     thinking: dict[str, ThinkingConfig] = Field(
         default_factory=dict,
         description="Per-archetype extended thinking configuration",
+    )
+    overrides: dict[str, PerArchetypeConfig] = Field(
+        default_factory=dict,
+        description=(
+            "Unified per-archetype configuration tables. "
+            "TOML: [archetypes.overrides.<name>]. "
+            "Takes precedence over models/max_turns/thinking/allowlists dicts."
+        ),
     )
 
     @field_validator("coder")

--- a/agent_fox/engine/sdk_params.py
+++ b/agent_fox/engine/sdk_params.py
@@ -22,14 +22,25 @@ logger = logging.getLogger(__name__)
 def resolve_max_turns(config: AgentFoxConfig, archetype: str) -> int | None:
     """Resolve max_turns for the given archetype.
 
-    Resolution order: config.toml override > archetype registry default.
+    Resolution order (highest to lowest priority):
+      1. archetypes.overrides.<name>.max_turns (unified table)
+      2. archetypes.max_turns.<name> (legacy dict)
+      3. Archetype registry default
     Returns None when configured as 0 (unlimited).
 
-    Requirements: 56-REQ-1.1, 56-REQ-1.2, 56-REQ-1.4, 56-REQ-5.1
+    Requirements: 56-REQ-1.1, 56-REQ-1.2, 56-REQ-1.4, 56-REQ-5.1, 207-REQ-2
     """
+    # 1. Unified per-archetype override table (highest priority)
+    override = config.archetypes.overrides.get(archetype)
+    if override is not None and override.max_turns is not None:
+        return override.max_turns if override.max_turns > 0 else None
+
+    # 2. Legacy dict
     configured = config.archetypes.max_turns.get(archetype)
     if configured is not None:
         return configured if configured > 0 else None  # 0 = unlimited
+
+    # 3. Registry default
     entry = get_archetype(archetype)
     return entry.default_max_turns
 
@@ -37,16 +48,30 @@ def resolve_max_turns(config: AgentFoxConfig, archetype: str) -> int | None:
 def resolve_thinking(config: AgentFoxConfig, archetype: str) -> dict | None:
     """Resolve thinking configuration for the given archetype.
 
-    Resolution order: config.toml override > archetype registry default.
+    Resolution order (highest to lowest priority):
+      1. archetypes.overrides.<name>.thinking_mode / thinking_budget (unified table)
+      2. archetypes.thinking.<name> (legacy dict)
+      3. Archetype registry default
     Returns None when mode is ``disabled``.
 
-    Requirements: 56-REQ-4.1, 56-REQ-4.2, 56-REQ-4.3, 56-REQ-5.1
+    Requirements: 56-REQ-4.1, 56-REQ-4.2, 56-REQ-4.3, 56-REQ-5.1, 207-REQ-2
     """
+    # 1. Unified per-archetype override table (highest priority)
+    override = config.archetypes.overrides.get(archetype)
+    if override is not None and override.thinking_mode is not None:
+        if override.thinking_mode == "disabled":
+            return None
+        budget = override.thinking_budget if override.thinking_budget is not None else 10000
+        return {"type": override.thinking_mode, "budget_tokens": budget}
+
+    # 2. Legacy dict
     configured = config.archetypes.thinking.get(archetype)
     if configured is not None:
         if configured.mode == "disabled":
             return None
         return {"type": configured.mode, "budget_tokens": configured.budget_tokens}
+
+    # 3. Registry default
     entry = get_archetype(archetype)
     if entry.default_thinking_mode == "disabled":
         return None

--- a/agent_fox/engine/session_lifecycle.py
+++ b/agent_fox/engine/session_lifecycle.py
@@ -226,16 +226,24 @@ class NodeSessionRunner:
     def _resolve_model_tier(self) -> str:
         """Resolve model tier for the archetype.
 
-        Priority: config override > archetype registry default > global coding model.
+        Priority (highest to lowest):
+          1. archetypes.overrides.<name>.model_tier (unified table)
+          2. archetypes.models.<name> (legacy dict)
+          3. Archetype registry default
 
-        Requirements: 26-REQ-4.4, 26-REQ-6.3
+        Requirements: 26-REQ-4.4, 26-REQ-6.3, 207-REQ-2
         """
-        # Check config override first
+        # 1. Unified per-archetype override table (highest priority)
+        override = self._config.archetypes.overrides.get(self._archetype)
+        if override and override.model_tier:
+            return override.model_tier
+
+        # 2. Legacy dict override
         config_override = self._config.archetypes.models.get(self._archetype)
         if config_override:
             return config_override
 
-        # Fall back to archetype registry default
+        # 3. Fall back to archetype registry default
         entry = get_archetype(self._archetype)
         return entry.default_model_tier
 
@@ -245,16 +253,25 @@ class NodeSessionRunner:
         Returns a SecurityConfig with the archetype's allowlist override,
         or None to use the global default.
 
-        Priority: config override > archetype registry default > None (global).
+        Priority (highest to lowest):
+          1. archetypes.overrides.<name>.allowlist (unified table)
+          2. archetypes.allowlists.<name> (legacy dict)
+          3. Archetype registry default
+          4. None → use global config.security
 
-        Requirements: 26-REQ-3.4, 26-REQ-6.4
+        Requirements: 26-REQ-3.4, 26-REQ-6.4, 207-REQ-2
         """
-        # Check config override first
+        # 1. Unified per-archetype override table (highest priority)
+        override = self._config.archetypes.overrides.get(self._archetype)
+        if override and override.allowlist is not None:
+            return SecurityConfig(bash_allowlist=override.allowlist)
+
+        # 2. Legacy dict override
         config_allowlist = self._config.archetypes.allowlists.get(self._archetype)
         if config_allowlist is not None:
             return SecurityConfig(bash_allowlist=config_allowlist)
 
-        # Fall back to archetype registry default
+        # 3. Fall back to archetype registry default
         entry = get_archetype(self._archetype)
         if entry.default_allowlist is not None:
             return SecurityConfig(bash_allowlist=entry.default_allowlist)

--- a/docs/archetypes.md
+++ b/docs/archetypes.md
@@ -276,8 +276,43 @@ default to STANDARD (Sonnet) for cost-effective implementation.
 
 ### Overriding Model Tiers via config.toml
 
-Override the default tier for any archetype in `config.toml` under
-`archetypes.models`:
+#### Unified per-archetype table (recommended)
+
+Use `[archetypes.overrides.<name>]` to configure all per-archetype settings
+in one place:
+
+```toml
+[archetypes.overrides.coder]
+model_tier = "ADVANCED"   # promote coder to Opus for complex specs
+max_turns = 200
+thinking_mode = "adaptive"
+
+[archetypes.overrides.skeptic]
+model_tier = "STANDARD"   # downgrade skeptic to Sonnet (cost reduction)
+max_turns = 50
+
+[archetypes.overrides.verifier]
+model_tier = "ADVANCED"
+max_turns = 75
+allowlist = ["ls", "cat", "git", "make", "uv"]
+```
+
+Each `[archetypes.overrides.<name>]` block supports:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `model_tier` | `"SIMPLE"` \| `"STANDARD"` \| `"ADVANCED"` | None (registry) | Model tier override |
+| `max_turns` | int ≥ 0 | None (registry) | Turn limit; 0 = unlimited |
+| `thinking_mode` | `"enabled"` \| `"adaptive"` \| `"disabled"` | None (registry) | Extended thinking mode |
+| `thinking_budget` | int ≥ 0 | None (10000) | Thinking budget tokens |
+| `allowlist` | list of strings | None (registry) | Bash command allowlist |
+
+`None` values fall through to the registry default. Any field not specified
+inherits from the archetype registry.
+
+#### Legacy dict syntax (backwards compatible)
+
+The older dict-based overrides remain supported:
 
 ```toml
 [archetypes.models]
@@ -289,9 +324,12 @@ verifier = "SIMPLE"     # downgrade verifier to Haiku
 Valid tier values are `"SIMPLE"` (Haiku), `"STANDARD"` (Sonnet), and
 `"ADVANCED"` (Opus). An invalid value raises a `ConfigError` at startup.
 
-Config overrides take precedence over registry defaults. If an adaptive
-routing assessment is available, the assessed tier takes precedence over both
-the config override and the registry default.
+**Resolution priority:** `[archetypes.overrides.<name>]` takes precedence
+over the legacy dict fields (`models`, `max_turns`, `thinking`, `allowlists`),
+which in turn take precedence over the archetype registry defaults.
+
+If an adaptive routing assessment is available, the assessed tier takes
+precedence over all config values.
 
 ### Escalation Behavior
 
@@ -331,14 +369,24 @@ skeptic = 1
 verifier = 1
 auditor = 1
 
-# Per-archetype model tier overrides
-[archetypes.models]
-coder = "ADVANCED"    # promote coder to Opus (default: STANDARD)
-skeptic = "STANDARD"  # downgrade skeptic to Sonnet (default: ADVANCED)
+# Unified per-archetype overrides (recommended — all knobs in one place)
+[archetypes.overrides.coder]
+model_tier = "ADVANCED"    # promote coder to Opus (default: STANDARD)
+max_turns = 200
+thinking_mode = "adaptive"
 
-# Per-archetype command allowlists
-[archetypes.allowlists]
-oracle = ["ls", "cat", "git", "grep", "find", "head", "tail", "wc"]
+[archetypes.overrides.skeptic]
+model_tier = "STANDARD"    # downgrade skeptic to Sonnet (default: ADVANCED)
+max_turns = 50
+
+[archetypes.overrides.verifier]
+model_tier = "ADVANCED"
+max_turns = 75
+
+# Legacy dict overrides (still supported for backwards compat)
+# [archetypes.models]
+# coder = "ADVANCED"
+# skeptic = "STANDARD"
 ```
 
 See the [archetypes ADR](adr/agent-archetypes.md) for the overall design

--- a/tests/unit/test_unified_archetype_config.py
+++ b/tests/unit/test_unified_archetype_config.py
@@ -1,0 +1,483 @@
+"""Unit tests for unified per-archetype configuration (issue #207).
+
+Validates the new [archetypes.overrides.<name>] TOML table syntax and
+resolution priority for model_tier, max_turns, thinking, and allowlist.
+
+Requirements: 207-REQ-1, 207-REQ-2, 207-REQ-3
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from agent_fox.core.config import (
+    AgentFoxConfig,
+    ArchetypesConfig,
+    PerArchetypeConfig,
+    load_config,
+)
+from agent_fox.engine.sdk_params import resolve_max_turns, resolve_thinking
+from agent_fox.knowledge.db import KnowledgeDB
+
+_MOCK_KB = MagicMock(spec=KnowledgeDB)
+
+
+# ---------------------------------------------------------------------------
+# PerArchetypeConfig — model validation
+# ---------------------------------------------------------------------------
+
+
+class TestPerArchetypeConfigParsing:
+    """PerArchetypeConfig parses all fields correctly."""
+
+    def test_all_fields_default_to_none(self) -> None:
+        """Default PerArchetypeConfig has all fields as None."""
+        cfg = PerArchetypeConfig()
+        assert cfg.model_tier is None
+        assert cfg.max_turns is None
+        assert cfg.thinking_mode is None
+        assert cfg.thinking_budget is None
+        assert cfg.allowlist is None
+
+    def test_model_tier_field(self) -> None:
+        cfg = PerArchetypeConfig(model_tier="ADVANCED")
+        assert cfg.model_tier == "ADVANCED"
+
+    def test_max_turns_field(self) -> None:
+        cfg = PerArchetypeConfig(max_turns=150)
+        assert cfg.max_turns == 150
+
+    def test_max_turns_zero_allowed(self) -> None:
+        """0 means unlimited — should be accepted."""
+        cfg = PerArchetypeConfig(max_turns=0)
+        assert cfg.max_turns == 0
+
+    def test_thinking_mode_enabled(self) -> None:
+        cfg = PerArchetypeConfig(thinking_mode="enabled", thinking_budget=20000)
+        assert cfg.thinking_mode == "enabled"
+        assert cfg.thinking_budget == 20000
+
+    def test_thinking_mode_adaptive(self) -> None:
+        cfg = PerArchetypeConfig(thinking_mode="adaptive")
+        assert cfg.thinking_mode == "adaptive"
+
+    def test_thinking_mode_disabled(self) -> None:
+        cfg = PerArchetypeConfig(thinking_mode="disabled")
+        assert cfg.thinking_mode == "disabled"
+
+    def test_allowlist_field(self) -> None:
+        cfg = PerArchetypeConfig(allowlist=["git", "grep"])
+        assert cfg.allowlist == ["git", "grep"]
+
+    def test_negative_max_turns_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            PerArchetypeConfig(max_turns=-1)
+
+    def test_negative_thinking_budget_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            PerArchetypeConfig(thinking_budget=-1)
+
+    def test_invalid_thinking_mode_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            PerArchetypeConfig(thinking_mode="turbo")  # type: ignore[arg-type]
+
+    def test_enabled_thinking_with_zero_budget_rejected(self) -> None:
+        """thinking_mode=enabled requires thinking_budget > 0."""
+        with pytest.raises((ValidationError, ValueError)):
+            PerArchetypeConfig(thinking_mode="enabled", thinking_budget=0)
+
+
+# ---------------------------------------------------------------------------
+# TOML Parsing — [archetypes.overrides.<name>]
+# ---------------------------------------------------------------------------
+
+
+class TestOverridesTomlParsing:
+    """[archetypes.overrides.<name>] parses correctly from TOML."""
+
+    def test_single_override_parsed(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            "[archetypes.overrides.coder]\n"
+            'model_tier = "ADVANCED"\n'
+            "max_turns = 200\n"
+        )
+        config = load_config(path=config_file)
+        assert "coder" in config.archetypes.overrides
+        coder = config.archetypes.overrides["coder"]
+        assert coder.model_tier == "ADVANCED"
+        assert coder.max_turns == 200
+
+    def test_multiple_overrides_parsed(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            "[archetypes.overrides.coder]\n"
+            'model_tier = "ADVANCED"\n'
+            "max_turns = 200\n"
+            "[archetypes.overrides.skeptic]\n"
+            'model_tier = "STANDARD"\n'
+            "max_turns = 50\n"
+        )
+        config = load_config(path=config_file)
+        assert config.archetypes.overrides["coder"].model_tier == "ADVANCED"
+        assert config.archetypes.overrides["skeptic"].model_tier == "STANDARD"
+        assert config.archetypes.overrides["skeptic"].max_turns == 50
+
+    def test_thinking_fields_parsed(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            "[archetypes.overrides.coder]\n"
+            'thinking_mode = "enabled"\n'
+            "thinking_budget = 32000\n"
+        )
+        config = load_config(path=config_file)
+        coder = config.archetypes.overrides["coder"]
+        assert coder.thinking_mode == "enabled"
+        assert coder.thinking_budget == 32000
+
+    def test_allowlist_field_parsed(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            "[archetypes.overrides.skeptic]\n"
+            'allowlist = ["ls", "cat", "git"]\n'
+        )
+        config = load_config(path=config_file)
+        assert config.archetypes.overrides["skeptic"].allowlist == ["ls", "cat", "git"]
+
+    def test_overrides_empty_by_default(self) -> None:
+        config = AgentFoxConfig()
+        assert config.archetypes.overrides == {}
+
+    def test_coexists_with_boolean_enables(self, tmp_path: Path) -> None:
+        """overrides and boolean enable flags work together."""
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            "[archetypes]\n"
+            "coder = true\n"
+            "skeptic = true\n"
+            "[archetypes.overrides.coder]\n"
+            'model_tier = "ADVANCED"\n'
+        )
+        config = load_config(path=config_file)
+        assert config.archetypes.coder is True
+        assert config.archetypes.overrides["coder"].model_tier == "ADVANCED"
+
+
+# ---------------------------------------------------------------------------
+# resolve_max_turns — priority: overrides > legacy > registry
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMaxTurnsWithOverrides:
+    """resolve_max_turns checks overrides first."""
+
+    def test_override_takes_precedence_over_legacy_dict(self) -> None:
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                max_turns={"coder": 100},  # legacy
+                overrides={"coder": PerArchetypeConfig(max_turns=200)},  # new
+            )
+        )
+        assert resolve_max_turns(config, "coder") == 200
+
+    def test_override_takes_precedence_over_registry(self) -> None:
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                overrides={"skeptic": PerArchetypeConfig(max_turns=40)},
+            )
+        )
+        assert resolve_max_turns(config, "skeptic") == 40
+
+    def test_override_zero_means_unlimited(self) -> None:
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                overrides={"coder": PerArchetypeConfig(max_turns=0)},
+            )
+        )
+        assert resolve_max_turns(config, "coder") is None
+
+    def test_legacy_dict_used_when_no_override(self) -> None:
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(max_turns={"coder": 150})
+        )
+        assert resolve_max_turns(config, "coder") == 150
+
+    def test_registry_default_used_when_neither(self) -> None:
+        """No override and no legacy dict → registry default."""
+        from agent_fox.session.archetypes import ARCHETYPE_REGISTRY
+
+        config = AgentFoxConfig()
+        expected = ARCHETYPE_REGISTRY["coder"].default_max_turns
+        assert resolve_max_turns(config, "coder") == expected
+
+    def test_override_none_max_turns_falls_through(self) -> None:
+        """PerArchetypeConfig with max_turns=None falls through to legacy dict."""
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                max_turns={"coder": 100},
+                overrides={"coder": PerArchetypeConfig(max_turns=None)},
+            )
+        )
+        assert resolve_max_turns(config, "coder") == 100
+
+
+# ---------------------------------------------------------------------------
+# resolve_thinking — priority: overrides > legacy > registry
+# ---------------------------------------------------------------------------
+
+
+class TestResolveThinkingWithOverrides:
+    """resolve_thinking checks overrides first."""
+
+    def test_override_thinking_mode_enabled(self) -> None:
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                overrides={"skeptic": PerArchetypeConfig(thinking_mode="enabled", thinking_budget=16000)},
+            )
+        )
+        result = resolve_thinking(config, "skeptic")
+        assert result == {"type": "enabled", "budget_tokens": 16000}
+
+    def test_override_thinking_mode_adaptive(self) -> None:
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                overrides={"verifier": PerArchetypeConfig(thinking_mode="adaptive")},
+            )
+        )
+        result = resolve_thinking(config, "verifier")
+        assert result is not None
+        assert result["type"] == "adaptive"
+        assert result["budget_tokens"] == 10000  # default budget
+
+    def test_override_thinking_mode_disabled(self) -> None:
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                overrides={"coder": PerArchetypeConfig(thinking_mode="disabled")},
+            )
+        )
+        result = resolve_thinking(config, "coder")
+        assert result is None
+
+    def test_override_takes_precedence_over_legacy_thinking_dict(self) -> None:
+        from agent_fox.core.config import ThinkingConfig
+
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                thinking={"coder": ThinkingConfig(mode="enabled", budget_tokens=5000)},
+                overrides={"coder": PerArchetypeConfig(thinking_mode="disabled")},
+            )
+        )
+        # Override wins → disabled
+        result = resolve_thinking(config, "coder")
+        assert result is None
+
+    def test_legacy_thinking_dict_used_when_no_override(self) -> None:
+        from agent_fox.core.config import ThinkingConfig
+
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                thinking={"skeptic": ThinkingConfig(mode="adaptive", budget_tokens=8000)},
+            )
+        )
+        result = resolve_thinking(config, "skeptic")
+        assert result == {"type": "adaptive", "budget_tokens": 8000}
+
+    def test_override_none_thinking_mode_falls_through(self) -> None:
+        """PerArchetypeConfig with thinking_mode=None falls through to legacy."""
+        from agent_fox.core.config import ThinkingConfig
+
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                thinking={"coder": ThinkingConfig(mode="enabled", budget_tokens=5000)},
+                overrides={"coder": PerArchetypeConfig(thinking_mode=None)},
+            )
+        )
+        # thinking_mode is None in override → check legacy
+        result = resolve_thinking(config, "coder")
+        assert result == {"type": "enabled", "budget_tokens": 5000}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_model_tier — priority: overrides > legacy > registry
+# ---------------------------------------------------------------------------
+
+
+class TestResolveModelTierWithOverrides:
+    """NodeSessionRunner._resolve_model_tier checks overrides first."""
+
+    def test_override_model_tier_takes_precedence(self) -> None:
+        from agent_fox.engine.session_lifecycle import NodeSessionRunner
+
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                models={"coder": "STANDARD"},  # legacy
+                overrides={"coder": PerArchetypeConfig(model_tier="ADVANCED")},  # new
+            )
+        )
+        runner = NodeSessionRunner("spec:1", config, archetype="coder", knowledge_db=_MOCK_KB)
+        # ADVANCED → claude-opus-4-6
+        assert runner._resolved_model_id == "claude-opus-4-6"
+
+    def test_override_standard_tier(self) -> None:
+        from agent_fox.engine.session_lifecycle import NodeSessionRunner
+
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                overrides={"skeptic": PerArchetypeConfig(model_tier="STANDARD")},
+            )
+        )
+        runner = NodeSessionRunner("spec:0", config, archetype="skeptic", knowledge_db=_MOCK_KB)
+        # STANDARD → claude-sonnet-4-6
+        assert runner._resolved_model_id == "claude-sonnet-4-6"
+
+    def test_legacy_models_dict_used_when_no_override(self) -> None:
+        from agent_fox.engine.session_lifecycle import NodeSessionRunner
+
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(models={"coder": "ADVANCED"})
+        )
+        runner = NodeSessionRunner("spec:1", config, archetype="coder", knowledge_db=_MOCK_KB)
+        assert runner._resolved_model_id == "claude-opus-4-6"
+
+    def test_override_none_model_tier_falls_through_to_legacy(self) -> None:
+        from agent_fox.engine.session_lifecycle import NodeSessionRunner
+
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                models={"coder": "ADVANCED"},
+                overrides={"coder": PerArchetypeConfig(model_tier=None)},
+            )
+        )
+        runner = NodeSessionRunner("spec:1", config, archetype="coder", knowledge_db=_MOCK_KB)
+        assert runner._resolved_model_id == "claude-opus-4-6"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_security_config — priority: overrides > legacy > registry
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSecurityConfigWithOverrides:
+    """NodeSessionRunner._resolve_security_config checks overrides first."""
+
+    def test_override_allowlist_takes_precedence(self) -> None:
+        from agent_fox.engine.session_lifecycle import NodeSessionRunner
+
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                allowlists={"coder": ["ls"]},  # legacy
+                overrides={"coder": PerArchetypeConfig(allowlist=["git", "grep"])},  # new
+            )
+        )
+        runner = NodeSessionRunner("spec:1", config, archetype="coder", knowledge_db=_MOCK_KB)
+        sec = runner._resolve_security_config()
+        assert sec is not None
+        assert sec.bash_allowlist == ["git", "grep"]
+
+    def test_legacy_allowlist_used_when_no_override(self) -> None:
+        from agent_fox.engine.session_lifecycle import NodeSessionRunner
+
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(allowlists={"coder": ["make", "uv"]})
+        )
+        runner = NodeSessionRunner("spec:1", config, archetype="coder", knowledge_db=_MOCK_KB)
+        sec = runner._resolve_security_config()
+        assert sec is not None
+        assert sec.bash_allowlist == ["make", "uv"]
+
+    def test_override_none_allowlist_falls_through_to_legacy(self) -> None:
+        from agent_fox.engine.session_lifecycle import NodeSessionRunner
+
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                allowlists={"coder": ["make"]},
+                overrides={"coder": PerArchetypeConfig(allowlist=None)},
+            )
+        )
+        runner = NodeSessionRunner("spec:1", config, archetype="coder", knowledge_db=_MOCK_KB)
+        sec = runner._resolve_security_config()
+        assert sec is not None
+        assert sec.bash_allowlist == ["make"]
+
+    def test_override_empty_allowlist_not_treated_as_none(self) -> None:
+        """An explicit empty list [] is a valid allowlist (no commands allowed)."""
+        from agent_fox.engine.session_lifecycle import NodeSessionRunner
+
+        config = AgentFoxConfig(
+            archetypes=ArchetypesConfig(
+                allowlists={"coder": ["make"]},  # legacy
+                overrides={"coder": PerArchetypeConfig(allowlist=[])},  # override with empty
+            )
+        )
+        runner = NodeSessionRunner("spec:1", config, archetype="coder", knowledge_db=_MOCK_KB)
+        sec = runner._resolve_security_config()
+        assert sec is not None
+        assert sec.bash_allowlist == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end TOML loading and resolution
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndTomlResolution:
+    """Full path: TOML file → load_config → resolve functions."""
+
+    def test_model_tier_from_toml_overrides_table(
+        self, tmp_path: Path
+    ) -> None:
+        from agent_fox.engine.session_lifecycle import NodeSessionRunner
+
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            "[archetypes.overrides.skeptic]\n"
+            'model_tier = "STANDARD"\n'
+        )
+        config = load_config(path=config_file)
+        runner = NodeSessionRunner("spec:0", config, archetype="skeptic", knowledge_db=_MOCK_KB)
+        # Registry default for skeptic is ADVANCED, but override is STANDARD → sonnet
+        assert runner._resolved_model_id == "claude-sonnet-4-6"
+
+    def test_max_turns_from_toml_overrides_table(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            "[archetypes.overrides.coder]\n"
+            "max_turns = 50\n"
+        )
+        config = load_config(path=config_file)
+        assert resolve_max_turns(config, "coder") == 50
+
+    def test_thinking_from_toml_overrides_table(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            "[archetypes.overrides.verifier]\n"
+            'thinking_mode = "enabled"\n'
+            "thinking_budget = 8000\n"
+        )
+        config = load_config(path=config_file)
+        result = resolve_thinking(config, "verifier")
+        assert result == {"type": "enabled", "budget_tokens": 8000}
+
+    def test_backwards_compat_legacy_max_turns_dict(self, tmp_path: Path) -> None:
+        """Old archetypes.max_turns dict style still works."""
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            "[archetypes.max_turns]\n"
+            "coder = 150\n"
+        )
+        config = load_config(path=config_file)
+        assert resolve_max_turns(config, "coder") == 150
+
+    def test_backwards_compat_legacy_thinking_dict(self, tmp_path: Path) -> None:
+        """Old archetypes.thinking dict style still works."""
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            '[archetypes.thinking.coder]\nmode = "enabled"\nbudget_tokens = 20000\n'
+        )
+        config = load_config(path=config_file)
+        result = resolve_thinking(config, "coder")
+        assert result == {"type": "enabled", "budget_tokens": 20000}


### PR DESCRIPTION
## Summary

Adds a `PerArchetypeConfig` model and `overrides` dict field to `ArchetypesConfig`, giving users a single consolidated TOML table for all per-archetype settings (model tier, max turns, thinking mode/budget, allowlist).

Closes #207

## Changes

| File | Change |
|------|--------|
| `agent_fox/core/config.py` | Add `PerArchetypeConfig` model; add `overrides: dict[str, PerArchetypeConfig]` to `ArchetypesConfig` |
| `agent_fox/engine/sdk_params.py` | Update `resolve_max_turns` and `resolve_thinking` to check overrides first |
| `agent_fox/engine/session_lifecycle.py` | Update `_resolve_model_tier` and `_resolve_security_config` to check overrides first |
| `tests/unit/test_unified_archetype_config.py` | 43 new tests covering parsing, resolution priority, and end-to-end TOML loading |
| `docs/archetypes.md` | Document new `[archetypes.overrides.*]` syntax and resolution priority table |
| `.agent-fox/config.toml` | Add commented examples for the new overrides table |

## Usage

```toml
[archetypes.overrides.coder]
model_tier = "ADVANCED"
max_turns = 200
thinking_mode = "adaptive"

[archetypes.overrides.skeptic]
model_tier = "STANDARD"   # reduce cost for skeptic reviews
max_turns = 50

[archetypes.overrides.verifier]
model_tier = "ADVANCED"
max_turns = 75
allowlist = ["ls", "cat", "git", "make", "uv"]
```

Resolution priority (highest wins):
1. `archetypes.overrides.<name>` (new unified table)
2. `archetypes.models` / `max_turns` / `thinking` / `allowlists` (legacy dicts — fully preserved)
3. Archetype registry defaults

**Note on `[archetypes.coder]` syntax:** The issue suggested `[archetypes.coder]` as the sub-table key. This conflicts with TOML's existing `archetypes.coder = true` boolean scalar. Using `[archetypes.overrides.coder]` achieves exactly the same result without breaking existing configs.

## Tests

- `tests/unit/test_unified_archetype_config.py`: 43 tests covering `PerArchetypeConfig` validation, TOML parsing, resolution priority for all four resolution paths (model_tier, max_turns, thinking, allowlist), and backwards compatibility.

## Verification

- All existing tests pass: ✅ (3754 total, 0 regressions)
- New tests pass: ✅ (43 new tests)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*