### PR TITLE
fix(platform): add url to GitHubPlatform.__repr__ to mask token (fixes #222)

### DIFF
--- a/agent_fox/platform/github.py
+++ b/agent_fox/platform/github.py
@@ -95,7 +95,7 @@ class GitHubPlatform:
             self._api_base = f"https://{self._url}/api/v3"
 
     def __repr__(self) -> str:
-        return f"GitHubPlatform(owner={self._owner!r}, repo={self._repo!r})"
+        return f"GitHubPlatform(owner={self._owner!r}, repo={self._repo!r}, url={self._url!r})"
 
     def _auth_headers(self) -> dict[str, str]:
         """Build authentication headers for GitHub API requests."""

--- a/tests/unit/platform/test_github_rest.py
+++ b/tests/unit/platform/test_github_rest.py
@@ -102,3 +102,40 @@ class TestGitHubPlatformRepr:
         platform = GitHubPlatform(owner="acme", repo="widgets", token="ghp_s3cret")
         result = str(platform)
         assert "ghp_s3cret" not in result
+
+    # ------------------------------------------------------------------
+    # AC-1: repr includes owner, repo, url; excludes token (issue #222)
+    # ------------------------------------------------------------------
+
+    def test_repr_exact_format_github_com(self) -> None:
+        """repr() includes owner, repo, url; token absent (AC-1)."""
+        platform = GitHubPlatform(
+            owner="octocat", repo="hello", token="ghp_secret123", url="github.com"
+        )
+        result = repr(platform)
+        assert result == "GitHubPlatform(owner='octocat', repo='hello', url='github.com')"
+        assert "ghp_secret123" not in result
+
+    # ------------------------------------------------------------------
+    # AC-2: Token absent for GitHub Enterprise URLs (issue #222)
+    # ------------------------------------------------------------------
+
+    def test_repr_enterprise_url_excludes_token(self) -> None:
+        """repr() excludes token and includes enterprise url (AC-2)."""
+        platform = GitHubPlatform(
+            owner="corp", repo="app", token="ghp_enterprisetoken", url="github.example.com"
+        )
+        result = repr(platform)
+        assert "ghp_enterprisetoken" not in result
+        assert "github.example.com" in result
+        assert result == "GitHubPlatform(owner='corp', repo='app', url='github.example.com')"
+
+    # ------------------------------------------------------------------
+    # AC-3: str() does not contain the token (issue #222)
+    # ------------------------------------------------------------------
+
+    def test_str_excludes_token_issue_222(self) -> None:
+        """str(instance) must not contain the token string (AC-3)."""
+        token = "ghp_unique_token_for_222"
+        platform = GitHubPlatform(owner="org", repo="project", token=token)
+        assert token not in str(platform)


### PR DESCRIPTION
## Summary

Adds the `url` field to `GitHubPlatform.__repr__` so the representation includes all non-sensitive fields (owner, repo, url) while continuing to exclude the PAT token. The existing `__repr__` already masked the token but omitted `url`, failing the acceptance criteria in issue #222.

Closes #222

## Changes

| File | Change |
|------|--------|
| `agent_fox/platform/github.py` | Added `url={self._url!r}` to `__repr__` return string |
| `tests/unit/platform/test_github_rest.py` | Added 3 regression tests for AC-1, AC-2, AC-3 |

## Tests

- `tests/unit/platform/test_github_rest.py`: exact repr format with url (AC-1), enterprise url excludes token (AC-2), str() excludes token (AC-3)

## Verification

- All existing tests pass: ✅
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*