### PR TITLE
fix(nightshift): wire spec generator into engine loop (fixes #302)

### DIFF
--- a/agent_fox/cli/nightshift.py
+++ b/agent_fox/cli/nightshift.py
@@ -125,5 +125,6 @@ def night_shift_cmd(ctx: click.Context, auto: bool) -> None:
         f"Night-shift stopped. "
         f"Scans completed: {state.hunt_scans_completed}, "
         f"Issues fixed: {state.issues_fixed}, "
+        f"Specs generated: {state.specs_generated}, "
         f"Total cost: ${state.total_cost:.4f}"
     )

--- a/agent_fox/nightshift/engine.py
+++ b/agent_fox/nightshift/engine.py
@@ -441,6 +441,109 @@ class NightShiftEngine:
             "bold green",
         )
 
+    async def _run_spec_gen(self) -> None:
+        """Poll platform for af:spec issues and process the oldest one.
+
+        Mirrors the crash-recovery and polling logic from
+        ``SpecGeneratorStream.run_once()`` but runs inline in the engine
+        loop, using ``SpecGenerator`` directly.
+
+        Requirements: 86-REQ-2.1, 86-REQ-2.2, 86-REQ-2.3,
+                      86-REQ-3.E1, 86-REQ-3.E2
+        """
+        self._clear_idle()
+        self._emit_status("Checking for af:spec issues\u2026")
+
+        from agent_fox.nightshift.spec_gen import (
+            LABEL_ANALYZING,
+            LABEL_GENERATING,
+            LABEL_PENDING,
+            LABEL_SPEC,
+            SpecGenerator,
+            SpecGenOutcome,
+        )
+
+        ns_config = getattr(self._config, "night_shift", None)
+        if ns_config is None:
+            logger.debug("No night_shift config; skipping spec gen")
+            return
+
+        repo_root = Path.cwd()
+        generator = SpecGenerator(
+            platform=self._platform,  # type: ignore[arg-type]
+            config=ns_config,
+            repo_root=repo_root,
+        )
+
+        # Crash recovery: reset stale analyzing/generating labels (86-REQ-3.E1, 86-REQ-3.E2)
+        for stale_label in (LABEL_ANALYZING, LABEL_GENERATING):
+            try:
+                stale_issues = await self._platform.list_issues_by_label(stale_label)  # type: ignore[attr-defined]
+                for issue in stale_issues:
+                    logger.warning(
+                        "Issue #%d has stale label %s; resetting to %s",
+                        issue.number,
+                        stale_label,
+                        LABEL_SPEC,
+                    )
+                    await self._platform.assign_label(issue.number, LABEL_SPEC)  # type: ignore[attr-defined]
+                    await self._platform.remove_label(issue.number, stale_label)  # type: ignore[attr-defined]
+            except Exception:
+                logger.exception("Error during crash recovery for label %s", stale_label)
+
+        # Poll for af:spec-pending issues with new human comments (86-REQ-2.3)
+        try:
+            pending_issues = await self._platform.list_issues_by_label(LABEL_PENDING)  # type: ignore[attr-defined]
+        except Exception:
+            logger.exception("Failed to list af:spec-pending issues")
+            pending_issues = []
+
+        for p_issue in pending_issues:
+            try:
+                comments = await self._platform.list_issue_comments(p_issue.number)  # type: ignore[attr-defined]
+                if generator._has_new_human_comment(comments):
+                    await self._platform.assign_label(p_issue.number, LABEL_ANALYZING)  # type: ignore[attr-defined]
+                    await self._platform.remove_label(p_issue.number, LABEL_PENDING)  # type: ignore[attr-defined]
+                    result = await generator.process_issue(p_issue)
+                    self.state.total_cost += result.cost
+                    if result.outcome == SpecGenOutcome.GENERATED:
+                        self.state.specs_generated += 1
+                    return
+            except Exception:
+                logger.exception("Error handling pending issue #%d", p_issue.number)
+
+        # Poll for af:spec issues (86-REQ-2.1)
+        try:
+            spec_issues = await self._platform.list_issues_by_label(  # type: ignore[attr-defined]
+                LABEL_SPEC,
+                sort="created",
+                direction="asc",
+            )
+        except Exception:
+            logger.warning(
+                "Spec gen check failed due to platform API error",
+                exc_info=True,
+            )
+            return
+
+        if not spec_issues:
+            return
+
+        # Process only the oldest issue (86-REQ-2.2)
+        issue = spec_issues[0]
+
+        try:
+            result = await generator.process_issue(issue)
+            self.state.total_cost += result.cost
+            if result.outcome == SpecGenOutcome.GENERATED:
+                self.state.specs_generated += 1
+        except Exception:
+            logger.warning(
+                "Spec generation failed for issue #%d, continuing",
+                issue.number,
+                exc_info=True,
+            )
+
     def _calculate_fix_cost(self, metrics: object) -> float:
         """Calculate USD cost from FixMetrics token counts."""
         from agent_fox.core.config import PricingConfig
@@ -602,6 +705,11 @@ class NightShiftEngine:
             "hunt_scan_interval",
             14400,
         )
+        spec_gen_interval = getattr(
+            getattr(self._config, "night_shift", None),
+            "spec_gen_interval",
+            300,
+        )
 
         # Initial run — issue-first gate (81-REQ-1.2)
         # Drain all af:fix issues before the first hunt scan.
@@ -628,9 +736,20 @@ class NightShiftEngine:
                         exc_info=True,
                     )
 
+        # Initial spec gen run — independent of issue-first gate
+        if not self.state.is_shutting_down:
+            try:
+                await self._run_spec_gen()
+            except Exception:
+                logger.warning(
+                    "Initial spec gen run failed",
+                    exc_info=True,
+                )
+
         # Timed loop — repeat checks at configured intervals
         issue_elapsed = 0.0
         hunt_elapsed = 0.0
+        spec_gen_elapsed = 0.0
         tick = 1.0  # seconds per tick
 
         while not self.state.is_shutting_down:
@@ -646,6 +765,7 @@ class NightShiftEngine:
             await asyncio.sleep(tick)
             issue_elapsed += tick
             hunt_elapsed += tick
+            spec_gen_elapsed += tick
 
             if issue_elapsed >= issue_interval:
                 issue_elapsed = 0.0
@@ -675,6 +795,10 @@ class NightShiftEngine:
                                 "Post-hunt issue drain failed",
                                 exc_info=True,
                             )
+
+            if spec_gen_elapsed >= spec_gen_interval:
+                spec_gen_elapsed = 0.0
+                await self._run_spec_gen()
 
             # Update idle spinner with next action time (81-REQ-4.1)
             issue_remaining = max(0.0, issue_interval - issue_elapsed)

--- a/agent_fox/nightshift/state.py
+++ b/agent_fox/nightshift/state.py
@@ -20,4 +20,5 @@ class NightShiftState:
     issues_created: int = 0
     issues_fixed: int = 0
     hunt_scans_completed: int = 0
+    specs_generated: int = 0
     is_shutting_down: bool = False

--- a/tests/integration/nightshift/test_engine.py
+++ b/tests/integration/nightshift/test_engine.py
@@ -1,7 +1,7 @@
 """Integration tests for NightShiftEngine.
 
-Test Spec: TS-61-1, TS-61-3, TS-61-28
-Requirements: 61-REQ-1.1, 61-REQ-1.3, 61-REQ-1.4, 61-REQ-9.3
+Test Spec: TS-61-1, TS-61-3, TS-61-28, TS-302-1
+Requirements: 61-REQ-1.1, 61-REQ-1.3, 61-REQ-1.4, 61-REQ-9.3, 86-REQ-2.1
 """
 
 from __future__ import annotations
@@ -31,6 +31,7 @@ class TestNightShiftStartsEventLoop:
         config.orchestrator.max_sessions = None
         config.night_shift.issue_check_interval = 900
         config.night_shift.hunt_scan_interval = 14400
+        config.night_shift.spec_gen_interval = 300
 
         mock_platform = AsyncMock()
         mock_platform.list_issues_by_label = AsyncMock(return_value=[])
@@ -68,6 +69,7 @@ class TestGracefulShutdown:
         config.orchestrator.max_sessions = None
         config.night_shift.issue_check_interval = 900
         config.night_shift.hunt_scan_interval = 14400
+        config.night_shift.spec_gen_interval = 300
 
         mock_platform = AsyncMock()
         mock_platform.list_issues_by_label = AsyncMock(return_value=[])
@@ -97,6 +99,148 @@ class TestGracefulShutdown:
 
 
 # ---------------------------------------------------------------------------
+# TS-302-1: Spec generator wired into engine loop
+# Requirement: 86-REQ-2.1
+# ---------------------------------------------------------------------------
+
+
+class TestSpecGenWiredIntoEngine:
+    """Verify that _run_spec_gen is called during the engine run loop."""
+
+    @pytest.mark.asyncio
+    async def test_spec_gen_runs_on_startup(self) -> None:
+        """Engine calls _run_spec_gen during its initial phase."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from agent_fox.nightshift.engine import NightShiftEngine
+
+        config = MagicMock()
+        config.orchestrator.max_cost = None
+        config.orchestrator.max_sessions = None
+        config.night_shift.issue_check_interval = 900
+        config.night_shift.hunt_scan_interval = 14400
+        config.night_shift.spec_gen_interval = 300
+
+        mock_platform = AsyncMock()
+        mock_platform.list_issues_by_label = AsyncMock(return_value=[])
+
+        engine = NightShiftEngine(config=config, platform=mock_platform)
+
+        spec_gen_called = False
+        original_run_spec_gen = engine._run_spec_gen
+
+        async def tracking_spec_gen() -> None:
+            nonlocal spec_gen_called
+            spec_gen_called = True
+            await original_run_spec_gen()
+
+        engine._run_spec_gen = tracking_spec_gen  # type: ignore[assignment]
+
+        async def shutdown_after_delay() -> None:
+            await asyncio.sleep(0.1)
+            engine.state.is_shutting_down = True
+
+        task = asyncio.create_task(engine.run())
+        asyncio.create_task(shutdown_after_delay())
+        await task
+
+        assert spec_gen_called, "_run_spec_gen was never called during engine.run()"
+
+    @pytest.mark.asyncio
+    async def test_spec_gen_processes_af_spec_issue(self) -> None:
+        """Engine processes an af:spec-labelled issue via SpecGenerator."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from agent_fox.nightshift.engine import NightShiftEngine
+        from agent_fox.nightshift.spec_gen import SpecGenOutcome, SpecGenResult
+        from agent_fox.platform.github import IssueResult
+
+        config = MagicMock()
+        config.orchestrator.max_cost = None
+        config.orchestrator.max_sessions = None
+        config.night_shift.issue_check_interval = 99999
+        config.night_shift.hunt_scan_interval = 99999
+        config.night_shift.spec_gen_interval = 300
+
+        spec_issue = IssueResult(number=10, title="Spec: new feature", html_url="http://spec")
+
+        mock_platform = AsyncMock()
+
+        def list_by_label(label: str, **kwargs: object) -> list[object]:
+            if label == "af:spec":
+                return [spec_issue]
+            return []
+
+        mock_platform.list_issues_by_label = AsyncMock(side_effect=list_by_label)
+
+        engine = NightShiftEngine(config=config, platform=mock_platform)
+
+        mock_result = SpecGenResult(
+            outcome=SpecGenOutcome.GENERATED,
+            issue_number=10,
+            spec_name="test_spec",
+            commit_hash="abc123",
+            cost=0.5,
+        )
+
+        with patch(
+            "agent_fox.nightshift.spec_gen.SpecGenerator",
+        ) as MockGenerator:
+            mock_gen_instance = AsyncMock()
+            mock_gen_instance.process_issue = AsyncMock(return_value=mock_result)
+            mock_gen_instance._has_new_human_comment = MagicMock(return_value=False)
+            MockGenerator.return_value = mock_gen_instance
+
+            async def shutdown_after_delay() -> None:
+                await asyncio.sleep(0.2)
+                engine.state.is_shutting_down = True
+
+            task = asyncio.create_task(engine.run())
+            asyncio.create_task(shutdown_after_delay())
+            result = await task
+
+        assert result.specs_generated == 1
+        assert result.total_cost >= 0.5
+
+    @pytest.mark.asyncio
+    async def test_spec_gen_runs_periodically(self) -> None:
+        """Engine calls _run_spec_gen on spec_gen_interval ticks."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from agent_fox.nightshift.engine import NightShiftEngine
+
+        config = MagicMock()
+        config.orchestrator.max_cost = None
+        config.orchestrator.max_sessions = None
+        config.night_shift.issue_check_interval = 99999
+        config.night_shift.hunt_scan_interval = 99999
+        config.night_shift.spec_gen_interval = 1
+
+        mock_platform = AsyncMock()
+        mock_platform.list_issues_by_label = AsyncMock(return_value=[])
+
+        engine = NightShiftEngine(config=config, platform=mock_platform)
+
+        spec_gen_count = 0
+
+        async def counting_spec_gen() -> None:
+            nonlocal spec_gen_count
+            spec_gen_count += 1
+
+        engine._run_spec_gen = counting_spec_gen  # type: ignore[assignment]
+
+        async def shutdown_after_delay() -> None:
+            await asyncio.sleep(2.5)
+            engine.state.is_shutting_down = True
+
+        task = asyncio.create_task(engine.run())
+        asyncio.create_task(shutdown_after_delay())
+        await task
+
+        assert spec_gen_count >= 2, f"Expected >=2 spec gen calls, got {spec_gen_count}"
+
+
+# ---------------------------------------------------------------------------
 # TS-61-28: Cost limit honoured
 # Requirement: 61-REQ-9.3
 # ---------------------------------------------------------------------------
@@ -118,6 +262,7 @@ class TestCostLimitHonoured:
         config.orchestrator.max_sessions = None
         config.night_shift.issue_check_interval = 60
         config.night_shift.hunt_scan_interval = 99999
+        config.night_shift.spec_gen_interval = 99999
 
         # Two af:fix issues, each costing 0.6
         issues = [

--- a/tests/integration/nightshift/test_nightshift_smoke.py
+++ b/tests/integration/nightshift/test_nightshift_smoke.py
@@ -36,6 +36,7 @@ def _make_config(
     config = MagicMock()
     config.night_shift.issue_check_interval = issue_interval
     config.night_shift.hunt_scan_interval = hunt_interval
+    config.night_shift.spec_gen_interval = 300
     config.orchestrator.max_cost = max_cost
     config.orchestrator.max_sessions = max_sessions
     return config

--- a/tests/property/nightshift/test_nightshift_props.py
+++ b/tests/property/nightshift/test_nightshift_props.py
@@ -231,6 +231,7 @@ class TestGracefulShutdownCompleteness:
         config.orchestrator.max_sessions = None
         config.night_shift.issue_check_interval = 900
         config.night_shift.hunt_scan_interval = 14400
+        config.night_shift.spec_gen_interval = 300
 
         mock_platform = AsyncMock()
         mock_platform.list_issues_by_label = AsyncMock(return_value=[])

--- a/tests/unit/nightshift/test_issue_first_gate.py
+++ b/tests/unit/nightshift/test_issue_first_gate.py
@@ -19,12 +19,14 @@ def _make_config(
     *,
     issue_interval: int = 900,
     hunt_interval: int = 14400,
+    spec_gen_interval: int = 300,
     max_cost: float | None = None,
     max_sessions: int | None = None,
 ) -> MagicMock:
     config = MagicMock()
     config.night_shift.issue_check_interval = issue_interval
     config.night_shift.hunt_scan_interval = hunt_interval
+    config.night_shift.spec_gen_interval = spec_gen_interval
     config.orchestrator.max_cost = max_cost
     config.orchestrator.max_sessions = max_sessions
     return config

--- a/tests/unit/nightshift/test_nightshift_callbacks.py
+++ b/tests/unit/nightshift/test_nightshift_callbacks.py
@@ -21,6 +21,7 @@ def _make_config() -> MagicMock:
     config.orchestrator.max_sessions = None
     config.night_shift.issue_check_interval = 900
     config.night_shift.hunt_scan_interval = 14400
+    config.night_shift.spec_gen_interval = 300
     return config
 
 

--- a/tests/unit/nightshift/test_nightshift_display.py
+++ b/tests/unit/nightshift/test_nightshift_display.py
@@ -29,6 +29,7 @@ def _make_config(
     config = MagicMock()
     config.night_shift.issue_check_interval = issue_interval
     config.night_shift.hunt_scan_interval = hunt_interval
+    config.night_shift.spec_gen_interval = 300
     config.orchestrator.max_cost = max_cost
     config.orchestrator.max_sessions = max_sessions
     return config


### PR DESCRIPTION
## Summary

- Wired the existing `SpecGenerator` into `NightShiftEngine.run()` as a third phase alongside issue checks and hunt scans
- Added `_run_spec_gen()` method with crash recovery for stale `af:spec-analyzing`/`af:spec-generating` labels, pending issue re-analysis, and `af:spec` issue processing
- Added `specs_generated` counter to `NightShiftState` and CLI shutdown summary

Closes #302

## Changes

| File | Change |
|------|--------|
| `agent_fox/nightshift/state.py` | Added `specs_generated: int = 0` counter |
| `agent_fox/nightshift/engine.py` | Added `_run_spec_gen()` method + wired into `run()` loop with initial call and `spec_gen_interval` timer |
| `agent_fox/cli/nightshift.py` | Added spec gen count to shutdown summary |
| `tests/integration/nightshift/test_engine.py` | 3 new regression tests |
| 5 test files | Added `spec_gen_interval` to config mocks |

## Tests

- `TestSpecGenWiredIntoEngine::test_spec_gen_runs_on_startup` — verifies initial call
- `TestSpecGenWiredIntoEngine::test_spec_gen_processes_af_spec_issue` — verifies af:spec issue processing and state updates
- `TestSpecGenWiredIntoEngine::test_spec_gen_runs_periodically` — verifies interval-based firing

## Verification

- All existing tests pass: ✅ (1 pre-existing failure in unrelated `test_archetypes.py`)
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*