### PR TITLE
fix(workspace): handle missing ref in has_new_commits gracefully (fixes #338)

### DIFF
--- a/agent_fox/workspace/git.py
+++ b/agent_fox/workspace/git.py
@@ -320,10 +320,13 @@ async def has_new_commits(
     """
     validate_ref_name(branch)
     validate_ref_name(base)
-    _rc, stdout, _stderr = await run_git(
+    rc, stdout, _stderr = await run_git(
         ["rev-list", "--count", f"{base}..{branch}"],
         cwd=repo_path,
+        check=False,
     )
+    if rc != 0:
+        return False
     return int(stdout.strip()) > 0
 
 

--- a/tests/unit/workspace/test_has_new_commits.py
+++ b/tests/unit/workspace/test_has_new_commits.py
@@ -1,0 +1,54 @@
+"""Tests for has_new_commits().
+
+Regression test for GitHub issue #338: git rev-list in has_new_commits()
+crashes session on missing ref instead of returning False.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent_fox.workspace.git import has_new_commits
+
+
+class TestHasNewCommitsMissingRef:
+    """Issue #338: has_new_commits returns False on missing ref instead of crashing."""
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_nonzero_exit(self) -> None:
+        """When git rev-list fails (exit 128), return False instead of raising."""
+        with patch(
+            "agent_fox.workspace.git.run_git",
+            new_callable=AsyncMock,
+            return_value=(128, "", "fatal: bad revision 'develop..feature/x'"),
+        ):
+            result = await has_new_commits(Path("/repo"), "feature/x", "develop")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_commits_ahead(self) -> None:
+        """Normal case: branch has commits ahead of base."""
+        with patch(
+            "agent_fox.workspace.git.run_git",
+            new_callable=AsyncMock,
+            return_value=(0, "3\n", ""),
+        ):
+            result = await has_new_commits(Path("/repo"), "feature/x", "develop")
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_commits_ahead(self) -> None:
+        """Branch is even with base — no new commits."""
+        with patch(
+            "agent_fox.workspace.git.run_git",
+            new_callable=AsyncMock,
+            return_value=(0, "0\n", ""),
+        ):
+            result = await has_new_commits(Path("/repo"), "feature/x", "develop")
+
+        assert result is False


### PR DESCRIPTION
## Summary

Add `check=False` to the `run_git` rev-list call in `has_new_commits()` so a missing ref (exit 128) returns `False` instead of raising `WorkspaceError` and crashing the session runner. This eliminates wasted retry attempts when refs aren't yet visible after worktree creation.

Closes #338

## Changes

| File | Change |
|------|--------|
| `agent_fox/workspace/git.py` | Add `check=False` to `run_git` call, return `False` on non-zero exit |
| `tests/unit/workspace/test_has_new_commits.py` | Regression test: missing ref returns False, normal cases work |

## Tests

- `test_has_new_commits.py`: 3 tests — missing-ref exit 128 → False, commits ahead → True, no commits → False

## Verification

- All existing tests pass: ✅ (4522 passed)
- New tests pass: ✅ (3 new)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*