### PR TITLE
fix(session): move artifacts into .agent-fox/ and clean up after read (fixes #340)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,7 @@ __pycache__/
 dist/
 build/
 
-# Session artifacts
-.session-summary.json
-.session-learnings.md
+# Test artifacts
 .hypothesis/
 
 # hacking

--- a/agent_fox/_templates/prompts/coding.md
+++ b/agent_fox/_templates/prompts/coding.md
@@ -114,9 +114,9 @@ Fix failures before proceeding. No regressions allowed.
 After quality gates pass (or if the session is ending due to failure), write a
 structured session summary file before committing.
 
-1. **File path:** `.session-summary.json` in the worktree root.
+1. **File path:** `.agent-fox/session-summary.json` in the worktree.
 2. **Do NOT commit this file.** It is a transient artifact read by the
-   orchestrator and discarded with the worktree.
+   orchestrator and deleted after processing.
 3. **Write the file** containing a JSON object with the following schema:
 
 ```json
@@ -138,51 +138,9 @@ structured session summary file before committing.
      modified. Each entry has a `path` (string) and `description` (string).
      Use an empty array `[]` when no tests were added or modified.
 5. **Failure entry:** If the session did not complete successfully or ended due
-   to failure, still write `.session-summary.json` with a summary describing
-   what was attempted and why it failed. Always include the
+   to failure, still write `.agent-fox/session-summary.json` with a summary
+   describing what was attempted and why it failed. Always include the
    `tests_added_or_modified` field (use `[]` if none).
-
-## SESSION LEARNINGS
-
-After the session summary (and before committing), write a learnings file so
-that future sessions can benefit from your discoveries. This step captures
-project-wide patterns — not task-specific implementation details.
-Only add new entries for genuinely new information.
-
-**Skip this step** if:
-- The session failed (quality gates did not pass).
-- This is a checkpoint/verification session.
-
-1. **File path:** `.session-learnings.md` in the worktree root.
-2. **Do NOT commit this file.** It is a transient artifact read by the
-   orchestrator and discarded with the worktree.
-3. **What belongs in this file:**
-
-   - Architecture: Major components, their responsibilities, and how they interact. Key dependencies.
-   - Conventions: Coding patterns, naming rules, structural idioms this project uses consistently.
-   - Decisions: Non-obvious choices that were made deliberately. Format as: "We use X (not Y) because Z."
-   - Fragile areas: Modules or subsystems that are sensitive to change, have known issues, or require extra care.
-   - Failed approaches: Things that were tried and didn't work, and why. Prevents re-exploring dead ends.
-   - Open questions: Areas of uncertainty or intentional deferral. Mark these clearly.
-
-   **What does not belong:**
-   - Information that's obvious from reading the code directly
-   - Fine-grained details that go stale quickly (specific function signatures, line numbers)
-   - Session logs or task summaries
-
-   **Examples:**
-
-   Good: "Hypothesis property tests fail when generated strings contain
-   brace characters that conflict with template syntax — use
-   `st.text(alphabet=...)` to restrict generators."
-
-   Bad: "Implemented the `render_drift_context` function in prompt.py
-   and updated 3 test files."
-
-4. **Content guardrails:**
-   - Only record **project-wide patterns and conventions**. Do not include
-     task-specific implementation details, session identifiers, or timestamps.
-   - Each bullet point: **1-2 sentences maximum**.
 
 ## LAND THE SESSION
 

--- a/agent_fox/core/paths.py
+++ b/agent_fox/core/paths.py
@@ -11,3 +11,4 @@ from pathlib import Path
 AGENT_FOX_DIR = ".agent-fox"
 DEFAULT_DB_PATH = Path(".agent-fox/knowledge.duckdb")
 AUDIT_DIR = Path(".agent-fox/audit")
+SESSION_SUMMARY_FILENAME = "session-summary.json"

--- a/agent_fox/engine/session_lifecycle.py
+++ b/agent_fox/engine/session_lifecycle.py
@@ -325,12 +325,15 @@ class NodeSessionRunner:
 
     @staticmethod
     def _read_session_artifacts(workspace: WorkspaceInfo) -> dict | None:
-        """Read .session-summary.json from the worktree if it exists.
+        """Read session-summary.json from the worktree if it exists.
 
+        Looks in ``.agent-fox/session-summary.json`` inside the worktree.
         Returns the parsed JSON dict or None if the file is absent or
         cannot be parsed.
         """
-        summary_path = workspace.path / ".session-summary.json"
+        from agent_fox.core.paths import AGENT_FOX_DIR, SESSION_SUMMARY_FILENAME
+
+        summary_path = workspace.path / AGENT_FOX_DIR / SESSION_SUMMARY_FILENAME
         if not summary_path.exists():
             return None
         try:
@@ -342,6 +345,22 @@ class NodeSessionRunner:
                 exc,
             )
             return None
+
+    @staticmethod
+    def _cleanup_session_artifacts(workspace: WorkspaceInfo) -> None:
+        """Delete transient session artifacts from the worktree.
+
+        Called after all consumers have read the artifacts.  Prevents
+        stale files from leaking into the working directory when worktree
+        cleanup is skipped or fails.
+        """
+        from agent_fox.core.paths import AGENT_FOX_DIR, SESSION_SUMMARY_FILENAME
+
+        summary_path = workspace.path / AGENT_FOX_DIR / SESSION_SUMMARY_FILENAME
+        try:
+            summary_path.unlink(missing_ok=True)
+        except OSError:
+            pass
 
     def _build_fallback_input(
         self,
@@ -827,6 +846,8 @@ class NodeSessionRunner:
                 node_id,
                 summary.get("summary", ""),
             )
+
+        self._cleanup_session_artifacts(workspace)
 
         return record
 

--- a/tests/unit/cli/test_code.py
+++ b/tests/unit/cli/test_code.py
@@ -589,7 +589,8 @@ class TestNodeSessionRunnerHarvestError:
             "tests_added_or_modified": [],
         }
 
-        summary_path = tmp_path / ".session-summary.json"
+        (tmp_path / ".agent-fox").mkdir(exist_ok=True)
+        summary_path = tmp_path / ".agent-fox" / "session-summary.json"
         summary_path.write_text(json.dumps(summary_data))
 
         workspace = WorkspaceInfo(

--- a/tests/unit/cli/test_knowledge_wiring.py
+++ b/tests/unit/cli/test_knowledge_wiring.py
@@ -55,7 +55,8 @@ class TestFactExtractionAfterSession:
 
         # Write a session summary artifact
         summary = {"summary": "Implemented feature X.", "tests_added_or_modified": []}
-        (tmp_path / ".session-summary.json").write_text(json.dumps(summary))
+        (tmp_path / ".agent-fox").mkdir(exist_ok=True)
+        (tmp_path / ".agent-fox" / "session-summary.json").write_text(json.dumps(summary))
 
         # Create spec dir so assemble_context doesn't fail
         spec_dir = Path.cwd() / ".specs" / "test_spec"
@@ -140,7 +141,8 @@ class TestFactExtractionAfterSession:
         outcome = _make_outcome(status="completed")
 
         summary = {"summary": "Implemented feature X."}
-        (tmp_path / ".session-summary.json").write_text(json.dumps(summary))
+        (tmp_path / ".agent-fox").mkdir(exist_ok=True)
+        (tmp_path / ".agent-fox" / "session-summary.json").write_text(json.dumps(summary))
 
         spec_dir = Path.cwd() / ".specs" / "test_spec"
         spec_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/engine/test_session_lifecycle.py
+++ b/tests/unit/engine/test_session_lifecycle.py
@@ -111,9 +111,10 @@ class TestReadSessionArtifacts:
     """Tests for NodeSessionRunner._read_session_artifacts."""
 
     def test_returns_parsed_json(self, tmp_path: Path) -> None:
-        """Valid .session-summary.json is parsed and returned."""
+        """Valid session-summary.json is parsed and returned."""
         summary = {"summary": "Did things", "tests_added_or_modified": []}
-        (tmp_path / ".session-summary.json").write_text(json.dumps(summary))
+        (tmp_path / ".agent-fox").mkdir()
+        (tmp_path / ".agent-fox" / "session-summary.json").write_text(json.dumps(summary))
         workspace = WorkspaceInfo(path=tmp_path, spec_name="s", task_group=1, branch="feature/s/1")
         result = NodeSessionRunner._read_session_artifacts(workspace)
         assert result == summary
@@ -124,10 +125,29 @@ class TestReadSessionArtifacts:
         assert NodeSessionRunner._read_session_artifacts(workspace) is None
 
     def test_returns_none_on_invalid_json(self, tmp_path: Path) -> None:
-        """Returns None when .session-summary.json contains invalid JSON."""
-        (tmp_path / ".session-summary.json").write_text("not valid json {{{")
+        """Returns None when session-summary.json contains invalid JSON."""
+        (tmp_path / ".agent-fox").mkdir(exist_ok=True)
+        (tmp_path / ".agent-fox" / "session-summary.json").write_text("not valid json {{{")
         workspace = WorkspaceInfo(path=tmp_path, spec_name="s", task_group=1, branch="feature/s/1")
         assert NodeSessionRunner._read_session_artifacts(workspace) is None
+
+
+class TestCleanupSessionArtifacts:
+    """Tests for NodeSessionRunner._cleanup_session_artifacts."""
+
+    def test_deletes_summary_file(self, tmp_path: Path) -> None:
+        """Cleanup removes session-summary.json."""
+        (tmp_path / ".agent-fox").mkdir()
+        summary_path = tmp_path / ".agent-fox" / "session-summary.json"
+        summary_path.write_text('{"summary": "done"}')
+        workspace = WorkspaceInfo(path=tmp_path, spec_name="s", task_group=1, branch="feature/s/1")
+        NodeSessionRunner._cleanup_session_artifacts(workspace)
+        assert not summary_path.exists()
+
+    def test_noop_when_missing(self, tmp_path: Path) -> None:
+        """Cleanup is a no-op when the file does not exist."""
+        workspace = WorkspaceInfo(path=tmp_path, spec_name="s", task_group=1, branch="feature/s/1")
+        NodeSessionRunner._cleanup_session_artifacts(workspace)  # should not raise
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Relocate session-summary.json from the worktree root into `.agent-fox/`, add explicit deletion after the orchestrator reads it, and remove the unused `.session-learnings.md` instruction from the coder template.

Closes #340

## Changes

| File | Change |
|------|--------|
| `agent_fox/core/paths.py` | Add `SESSION_SUMMARY_FILENAME` constant |
| `agent_fox/engine/session_lifecycle.py` | Update `_read_session_artifacts()` path to `.agent-fox/`; add `_cleanup_session_artifacts()` |
| `agent_fox/_templates/prompts/coding.md` | Update summary path; remove SESSION LEARNINGS section |
| `.gitignore` | Remove root-level `.session-summary.json` and `.session-learnings.md` entries |
| `tests/unit/engine/test_session_lifecycle.py` | Update paths; add `TestCleanupSessionArtifacts` (2 tests) |
| `tests/unit/cli/test_code.py` | Update artifact path |
| `tests/unit/cli/test_knowledge_wiring.py` | Update artifact paths |

## Tests

- `TestCleanupSessionArtifacts::test_deletes_summary_file` — verifies file is deleted
- `TestCleanupSessionArtifacts::test_noop_when_missing` — verifies no error when absent

## Verification

- All existing tests pass: ✅
- New tests pass: ✅ (4524 total, +2)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*