### PR TITLE
fix(graph,session): use specs_dir and project_root instead of hardcoded paths (fixes #355)

### DIFF
--- a/agent_fox/engine/review_persistence.py
+++ b/agent_fox/engine/review_persistence.py
@@ -383,7 +383,7 @@ def persist_review_findings(
                     )
 
             spec_dir = Path.cwd() / ".specs" / spec_name
-            persist_auditor_results(spec_dir, audit_result, attempt=attempt)
+            persist_auditor_results(spec_dir, audit_result, attempt=attempt, project_root=Path.cwd())
 
     except Exception:
         logger.warning(

--- a/agent_fox/graph/injection.py
+++ b/agent_fox/graph/injection.py
@@ -305,7 +305,9 @@ def ensure_graph_archetypes(
                 continue
 
             # Resolve spec path for TS count
-            candidate_path = Path(f".specs/{spec}")
+            if specs_dir is None:
+                continue
+            candidate_path = specs_dir / spec
             if not candidate_path.exists():
                 continue
             ts_count = count_ts_entries(candidate_path)

--- a/agent_fox/session/auditor_output.py
+++ b/agent_fox/session/auditor_output.py
@@ -34,6 +34,7 @@ def persist_auditor_results(
     result: AuditResult,
     *,
     attempt: int = 1,
+    project_root: Path | None = None,
 ) -> None:
     """Write audit findings to .agent-fox/audit/audit_{spec_name}.md.
 
@@ -43,12 +44,21 @@ def persist_auditor_results(
 
     Handles filesystem errors gracefully — logs and does not raise.
 
+    Args:
+        spec_dir: Path to the spec directory (e.g. ``.specs/05_foo``).
+        result: The audit result to persist.
+        attempt: The attempt number for the audit report header.
+        project_root: Root directory of the project (parent of
+            ``.agent-fox/``).  Falls back to ``spec_dir.parent.parent``
+            when not supplied, for backward compatibility.
+
     Requirements: 46-REQ-8.1, 46-REQ-8.E2,
                   92-REQ-1.1, 92-REQ-1.2, 92-REQ-1.3, 92-REQ-1.E1,
                   92-REQ-2.1, 92-REQ-3.1, 92-REQ-3.E1, 92-REQ-3.E2
     """
     spec_name = spec_dir.name
-    audit_dir = spec_dir.parent.parent / ".agent-fox" / "audit"
+    root = project_root if project_root is not None else spec_dir.parent.parent
+    audit_dir = root / ".agent-fox" / "audit"
     audit_path = audit_dir / f"audit_{spec_name}.md"
 
     # PASS verdict: delete existing report and return (do not write).

--- a/tests/unit/graph/test_builder_auditor.py
+++ b/tests/unit/graph/test_builder_auditor.py
@@ -550,3 +550,68 @@ class TestPropertyInjectionIntegrity:
 
         assert len(incoming) == 1
         assert len(outgoing) <= 1
+
+
+# ---------------------------------------------------------------------------
+# Regression: ensure_graph_archetypes uses specs_dir, not hardcoded .specs/
+# Issue: #355
+# ---------------------------------------------------------------------------
+
+
+class TestAutoMidUsesSpecsDir:
+    """Verify auto_mid injection uses the specs_dir parameter, not a hardcoded path."""
+
+    def test_auto_mid_injection_with_custom_specs_dir(self, tmp_path: Path) -> None:
+        """Regression for #355: auto_mid must use specs_dir, not Path('.specs/...')."""
+        from agent_fox.core.config import ArchetypesConfig, ReviewerConfig
+        from agent_fox.graph.injection import ensure_graph_archetypes
+        from agent_fox.graph.types import Edge, Node, TaskGraph
+
+        # Create spec dir at a non-standard location (NOT .specs/)
+        custom_specs = tmp_path / "custom_specs"
+        spec_dir = custom_specs / "myspec"
+        spec_dir.mkdir(parents=True)
+        ts_content = "\n".join(f"### TS-X-{i}\nDesc\n" for i in range(1, 8))
+        (spec_dir / "test_spec.md").write_text(ts_content)
+
+        # Build a graph with two coder groups, one test-writing
+        nodes = {
+            "myspec:1": Node(id="myspec:1", spec_name="myspec", group_number=1, title="Write failing spec tests", optional=False),
+            "myspec:2": Node(id="myspec:2", spec_name="myspec", group_number=2, title="Implement core", optional=False),
+        }
+        edges = [Edge(source="myspec:1", target="myspec:2", kind="intra_spec")]
+        graph = TaskGraph(nodes=nodes, edges=edges, order=["myspec:1", "myspec:2"])
+
+        config = ArchetypesConfig(
+            reviewer=True,
+            reviewer_config=ReviewerConfig(audit_min_ts_entries=5),
+        )
+
+        injected = ensure_graph_archetypes(graph, config, specs_dir=custom_specs)
+        assert injected, "auto_mid should inject when specs_dir points to valid spec dir"
+
+        audit_nodes = [n for n in graph.nodes.values() if n.archetype == "reviewer" and n.mode == "audit-review"]
+        assert len(audit_nodes) == 1
+
+    def test_auto_mid_skips_when_specs_dir_is_none(self) -> None:
+        """When specs_dir is None, auto_mid injection should be skipped."""
+        from agent_fox.core.config import ArchetypesConfig, ReviewerConfig
+        from agent_fox.graph.injection import ensure_graph_archetypes
+        from agent_fox.graph.types import Edge, Node, TaskGraph
+
+        nodes = {
+            "myspec:1": Node(id="myspec:1", spec_name="myspec", group_number=1, title="Write failing spec tests", optional=False),
+            "myspec:2": Node(id="myspec:2", spec_name="myspec", group_number=2, title="Implement core", optional=False),
+        }
+        edges = [Edge(source="myspec:1", target="myspec:2", kind="intra_spec")]
+        graph = TaskGraph(nodes=nodes, edges=edges, order=["myspec:1", "myspec:2"])
+
+        config = ArchetypesConfig(
+            reviewer=True,
+            reviewer_config=ReviewerConfig(audit_min_ts_entries=5),
+        )
+
+        injected = ensure_graph_archetypes(graph, config, specs_dir=None)
+
+        audit_nodes = [n for n in graph.nodes.values() if n.archetype == "reviewer" and n.mode == "audit-review"]
+        assert len(audit_nodes) == 0, "auto_mid should not inject when specs_dir is None"

--- a/tests/unit/session/test_transient_audit.py
+++ b/tests/unit/session/test_transient_audit.py
@@ -371,3 +371,37 @@ class TestCleanupPartialFailure:
             "warning" in r.levelname.lower() or "error" in r.message.lower() or "failed" in r.message.lower()
             for r in caplog.records
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression: persist_auditor_results uses explicit project_root (#355)
+# ---------------------------------------------------------------------------
+
+
+class TestProjectRootParameter:
+    """Verify persist_auditor_results uses project_root instead of parent.parent."""
+
+    def test_explicit_project_root(self, tmp_path: Path) -> None:
+        """Regression for #355: project_root overrides spec_dir.parent.parent."""
+        from agent_fox.session.auditor_output import persist_auditor_results
+
+        # spec_dir is deeply nested — parent.parent would be wrong
+        spec_dir = tmp_path / "some" / "deep" / "path" / "myspec"
+        spec_dir.mkdir(parents=True)
+
+        persist_auditor_results(spec_dir, _make_fail_result(), project_root=tmp_path)
+
+        audit_path = tmp_path / ".agent-fox" / "audit" / "audit_myspec.md"
+        assert audit_path.exists(), "audit report should be at project_root/.agent-fox/audit/"
+
+    def test_fallback_to_parent_parent(self, tmp_path: Path) -> None:
+        """Without project_root, falls back to spec_dir.parent.parent."""
+        from agent_fox.session.auditor_output import persist_auditor_results
+
+        spec_dir = tmp_path / ".specs" / "05_foo"
+        spec_dir.mkdir(parents=True)
+
+        persist_auditor_results(spec_dir, _make_fail_result())
+
+        audit_path = tmp_path / ".agent-fox" / "audit" / "audit_05_foo.md"
+        assert audit_path.exists(), "fallback should still work for standard .specs/ layout"


### PR DESCRIPTION
## Summary

Fixed two hardcoded `.specs/` path assumptions that break when specs are archived or non-standard paths are used. Auto_mid injection now uses the `specs_dir` parameter, and `persist_auditor_results` now accepts explicit `project_root`.

Closes #355

## Changes

| File | Change |
|------|--------|
| `agent_fox/graph/injection.py` | Use `specs_dir / spec` for auto_mid path; guard with `specs_dir is None` |
| `agent_fox/session/auditor_output.py` | Add `project_root: Path \| None` kwarg to `persist_auditor_results` |
| `agent_fox/engine/review_persistence.py` | Pass `project_root=Path.cwd()` to `persist_auditor_results` |
| `tests/unit/graph/test_builder_auditor.py` | Add `TestAutoMidUsesSpecsDir` (2 tests) |
| `tests/unit/session/test_transient_audit.py` | Add `TestProjectRootParameter` (2 tests) |

## Tests

- `TestAutoMidUsesSpecsDir` — verifies injection with custom specs_dir and graceful skip when None
- `TestProjectRootParameter` — verifies explicit project_root and backward-compatible fallback

## Verification

- All existing tests pass: ✅
- New tests pass: ✅ (4528 total, +4)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*