### PR TITLE
chore(workspace): remove leftover hooks directory scaffolding (fixes #374)

### DIFF
--- a/agent_fox/workspace/init_project.py
+++ b/agent_fox/workspace/init_project.py
@@ -533,7 +533,6 @@ def init_project(
             config_path.write_text(merged_content, encoding="utf-8")
 
         # Ensure structure is complete
-        (agent_fox_dir / "hooks").mkdir(parents=True, exist_ok=True)
         (agent_fox_dir / "worktrees").mkdir(parents=True, exist_ok=True)
         _ensure_seed_files(path)
         _update_gitignore(path)
@@ -560,7 +559,6 @@ def init_project(
 
     # Fresh initialization
     _secure_mkdir(agent_fox_dir)
-    (agent_fox_dir / "hooks").mkdir(exist_ok=True)
     (agent_fox_dir / "worktrees").mkdir(exist_ok=True)
 
     from agent_fox.core.config_gen import generate_default_config

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -38,12 +38,6 @@ class TestInitCreatesStructure:
         content = config_path.read_text()
         assert isinstance(content, str)
 
-    def test_init_creates_hooks_directory(self, cli_runner: CliRunner, tmp_git_repo: Path) -> None:
-        """init creates .agent-fox/hooks/ directory."""
-        cli_runner.invoke(main, ["init"])
-
-        assert (tmp_git_repo / ".agent-fox" / "hooks").is_dir()
-
     def test_init_creates_worktrees_directory(self, cli_runner: CliRunner, tmp_git_repo: Path) -> None:
         """init creates .agent-fox/worktrees/ directory."""
         cli_runner.invoke(main, ["init"])


### PR DESCRIPTION
## Summary

Removes two stale `.mkdir` calls for `.agent-fox/hooks/` from `init_project.py` and deletes the associated integration test. The hooks runtime directory was left behind when spec 103 removed the hook runner system.

Closes #374

## Changes

| File | Change |
|------|--------|
| `agent_fox/workspace/init_project.py` | Removed `(agent_fox_dir / "hooks").mkdir()` from both re-init and fresh-init paths |
| `tests/integration/test_init.py` | Deleted `test_init_creates_hooks_directory` test method |

## Verification

- All existing tests pass: ✅ (4633 passed)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*