### PR TITLE
fix(status): remove Memory line from status command header (fixes #375)

### DIFF
--- a/agent_fox/reporting/formatters.py
+++ b/agent_fox/reporting/formatters.py
@@ -87,13 +87,6 @@ class TableFormatter:
             task_parts.append(f"agents running: {agent_names}")
         lines.append(" | ".join(task_parts))
 
-        # Memory line
-        if report.memory_total > 0:
-            cat_parts = ", ".join(f"{count} {cat}" for cat, count in sorted(report.memory_by_category.items()))
-            lines.append(f"Memory: {report.memory_total} facts ({cat_parts})")
-        else:
-            lines.append("Memory: 0 facts")
-
         # Tokens line
         in_tok = format_tokens(report.input_tokens)
         out_tok = format_tokens(report.output_tokens)

--- a/tests/unit/reporting/test_formatters.py
+++ b/tests/unit/reporting/test_formatters.py
@@ -14,6 +14,7 @@ import pytest
 from agent_fox.core.errors import AgentFoxError
 from agent_fox.reporting.formatters import (
     JsonFormatter,
+    TableFormatter,
     write_output,
 )
 from agent_fox.reporting.standup import (
@@ -113,6 +114,43 @@ def _make_standup_report() -> StandupReport:
             completed=4,
         ),
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #375: TableFormatter must not display Memory line in status header
+# ---------------------------------------------------------------------------
+
+
+class TestTableFormatter:
+    """Regression tests for TableFormatter.format_status text output."""
+
+    def test_memory_line_absent_when_zero_facts(self) -> None:
+        """'Memory: 0 facts' must not appear in status output (issue #375)."""
+        formatter = TableFormatter()
+        report = _make_status_report()  # memory_total defaults to 0
+
+        output = formatter.format_status(report)
+
+        assert "Memory" not in output, (
+            "Status header must not contain a Memory line (issue #375)"
+        )
+
+    def test_memory_line_absent_when_facts_present(self) -> None:
+        """'Memory: N facts' must not appear even when facts exist (issue #375)."""
+        import dataclasses
+
+        formatter = TableFormatter()
+        report = dataclasses.replace(
+            _make_status_report(),
+            memory_total=5,
+            memory_by_category={"pattern": 3, "decision": 2},
+        )
+
+        output = formatter.format_status(report)
+
+        assert "Memory" not in output, (
+            "Status header must not contain a Memory line even when facts exist (issue #375)"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Removes the `Memory: N facts` line from the `af status` text output. It was always shown (even as `Memory: 0 facts` when empty) and adds no actionable value.

Closes #375

## Changes

| File | Change |
|------|--------|
| `agent_fox/reporting/formatters.py` | Remove 6-line Memory display block from `format_status_report` |
| `tests/unit/reporting/test_formatters.py` | Add `TestTableFormatter` with 2 regression tests |

## Tests

- `test_memory_line_absent_when_zero_facts`: verifies no Memory line when memory_total=0
- `test_memory_line_absent_when_facts_present`: verifies no Memory line even when facts exist

## Verification

- All existing tests pass: ✅ (4635 total, +2 new)
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*