### PR TITLE
fix(state): decouple session/run loading from plan_nodes in load_state_from_db (fixes #379)

### DIFF
--- a/agent_fox/engine/state.py
+++ b/agent_fox/engine/state.py
@@ -238,17 +238,22 @@ def load_state_from_db(
     """Reconstruct an ExecutionState from DB tables.
 
     Loads node_states from plan_nodes, session history from
-    session_outcomes, blocked reasons, and run totals. Returns None
-    if no plan data exists in the database.
+    session_outcomes, blocked reasons, and run totals.
+
+    Returns None only when the plan_nodes table cannot be queried at all
+    (e.g. the table does not exist or the DB is corrupt). An empty
+    plan_nodes table is valid — session_outcomes and runs are populated
+    independently of the plan (e.g. nightshift execution path) and must
+    always be loaded regardless.
 
     Requirements: 105-REQ-5.3
     """
-    # Load node states from plan_nodes
+    # Load node states from plan_nodes.
+    # An empty result is normal (nightshift path); only a query failure
+    # (missing table, corrupt DB) warrants returning None.
     try:
         rows = conn.sql("SELECT id, status FROM plan_nodes").fetchall()
     except Exception:
-        return None
-    if not rows:
         return None
     node_states = {row[0]: row[1] for row in rows}
 

--- a/tests/unit/engine/test_db_plan_state.py
+++ b/tests/unit/engine/test_db_plan_state.py
@@ -491,3 +491,71 @@ def test_missing_db_status(tmp_path) -> None:
     result = generate_status(db_path=nonexistent_db)
     # Either result contains "No plan found" or is a falsy/empty value
     assert result is None or "No plan found" in str(result) or result == {}
+
+
+# -- Regression tests: issue #379 — load_state_from_db gates on plan_nodes ----
+
+
+def test_load_state_from_db_empty_plan_nodes_loads_sessions(
+    db_conn: duckdb.DuckDBPyConnection,
+) -> None:
+    """Regression #379: load_state_from_db returns session history even when plan_nodes is empty.
+
+    Previously the function returned None immediately when plan_nodes was empty,
+    silently discarding all session_outcomes data.
+    """
+    from agent_fox.engine.state import load_state_from_db
+
+    # plan_nodes is empty (no rows inserted)
+    assert db_conn.sql("SELECT COUNT(*) FROM plan_nodes").fetchone()[0] == 0
+
+    # Populate session_outcomes with real data
+    db_conn.execute(
+        """
+        INSERT INTO session_outcomes
+            (id, spec_name, task_group, node_id, status,
+             input_tokens, output_tokens, cost, duration_ms,
+             created_at, run_id, attempt, model, archetype, commit_sha,
+             error_message, is_transport_error)
+        VALUES ('s1', 'spec_a', '1', 'spec_a:1', 'completed',
+                5000, 2500, 0.75, 30000,
+                '2026-01-01T00:00:00', 'run_1', 1, 'claude-sonnet-4-6',
+                'coder', 'abc123', NULL, FALSE)
+        """
+    )
+
+    state = load_state_from_db(db_conn)
+
+    assert state is not None, "load_state_from_db must not return None when sessions exist"
+    assert len(state.session_history) == 1
+    assert state.session_history[0].node_id == "spec_a:1"
+    assert state.session_history[0].input_tokens == 5000
+    assert abs(state.session_history[0].cost - 0.75) < 1e-9
+    assert state.node_states == {}  # empty plan, not an error
+
+
+def test_load_state_from_db_empty_plan_nodes_loads_run_totals(
+    db_conn: duckdb.DuckDBPyConnection,
+) -> None:
+    """Regression #379: load_state_from_db returns run totals even when plan_nodes is empty.
+
+    The runs table is written by the engine's result handler and exists
+    independently of plan_nodes. Token counts and costs must always be read.
+    """
+    from agent_fox.engine.state import load_state_from_db
+
+    # plan_nodes is empty
+    assert db_conn.sql("SELECT COUNT(*) FROM plan_nodes").fetchone()[0] == 0
+
+    # Populate runs table
+    create_run(db_conn, "run_1", "hash_abc")
+    update_run_totals(db_conn, "run_1", input_tokens=10000, output_tokens=4000, cost=1.50)
+    complete_run(db_conn, "run_1", "completed")
+
+    state = load_state_from_db(db_conn)
+
+    assert state is not None, "load_state_from_db must not return None when run data exists"
+    assert state.total_input_tokens == 10000
+    assert state.total_output_tokens == 4000
+    assert abs(state.total_cost - 1.50) < 1e-6
+    assert state.node_states == {}  # empty plan, not an error

--- a/tests/unit/reporting/test_status.py
+++ b/tests/unit/reporting/test_status.py
@@ -274,3 +274,132 @@ class TestStatusNoPlanFile:
             generate_status(plan_path=bad_plan)
 
         assert "plan" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Regression: issue #379 — generate_status shows correct cost when
+# plan_nodes is empty but session_outcomes / runs tables have data.
+# ---------------------------------------------------------------------------
+
+
+class TestStatusEmptyPlanNodes:
+    """Regression #379: token counts/costs must not be gated on plan_nodes."""
+
+    def test_correct_cost_when_plan_nodes_empty(
+        self,
+        tmp_plan_dir: Path,
+    ) -> None:
+        """generate_status shows real cost/tokens from DB even when plan_nodes is empty.
+
+        Preconditions: plan.json exists, DB has session_outcomes/runs data but
+        plan_nodes table is empty (nightshift execution path).
+        Expected: StatusReport reflects actual token counts and cost from DB.
+        Assertion: report.input_tokens > 0 and report.estimated_cost > 0.
+        """
+        import duckdb
+
+        from agent_fox.engine.state import (
+            SessionOutcomeRecord,
+            create_run,
+            record_session,
+            update_run_totals,
+        )
+
+        nodes = {
+            "spec_a:1": {"title": "Task 1"},
+            "spec_a:2": {"title": "Task 2"},
+        }
+        plan_path = write_plan_file(tmp_plan_dir, nodes=nodes)
+
+        # Build a real in-memory DB with session data but empty plan_nodes
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            """
+            CREATE TABLE plan_nodes (
+                id VARCHAR PRIMARY KEY, spec_name VARCHAR NOT NULL,
+                group_number INTEGER NOT NULL, title VARCHAR NOT NULL,
+                body TEXT NOT NULL DEFAULT '', archetype VARCHAR NOT NULL DEFAULT 'coder',
+                mode VARCHAR, model_tier VARCHAR,
+                status VARCHAR NOT NULL DEFAULT 'pending',
+                subtask_count INTEGER NOT NULL DEFAULT 0,
+                optional BOOLEAN NOT NULL DEFAULT FALSE,
+                instances INTEGER NOT NULL DEFAULT 1,
+                sort_position INTEGER NOT NULL DEFAULT 0,
+                blocked_reason VARCHAR,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE plan_meta (
+                id INTEGER PRIMARY KEY, content_hash VARCHAR NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                fast_mode BOOLEAN NOT NULL DEFAULT FALSE,
+                filtered_spec VARCHAR, version VARCHAR NOT NULL DEFAULT ''
+            );
+            CREATE TABLE runs (
+                id VARCHAR PRIMARY KEY, plan_content_hash VARCHAR NOT NULL,
+                started_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                completed_at TIMESTAMP,
+                status VARCHAR NOT NULL DEFAULT 'running',
+                total_input_tokens BIGINT NOT NULL DEFAULT 0,
+                total_output_tokens BIGINT NOT NULL DEFAULT 0,
+                total_cost DOUBLE NOT NULL DEFAULT 0.0,
+                total_sessions INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE session_outcomes (
+                id VARCHAR PRIMARY KEY, spec_name VARCHAR, task_group VARCHAR,
+                node_id VARCHAR, touched_path VARCHAR, status VARCHAR,
+                input_tokens INTEGER, output_tokens INTEGER, duration_ms INTEGER,
+                created_at TIMESTAMP, run_id VARCHAR, attempt INTEGER DEFAULT 1,
+                cost DOUBLE DEFAULT 0.0, model VARCHAR, archetype VARCHAR,
+                commit_sha VARCHAR, error_message TEXT,
+                is_transport_error BOOLEAN DEFAULT FALSE
+            );
+            CREATE TABLE IF NOT EXISTS audit_events (
+                id VARCHAR PRIMARY KEY,
+                event_type VARCHAR,
+                payload VARCHAR,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+            """
+        )
+        # plan_nodes is empty — the nightshift case
+
+        # Insert session data
+        create_run(conn, "run_1", "hash_abc")
+        record_session(
+            conn,
+            SessionOutcomeRecord(
+                id="s1",
+                spec_name="spec_a",
+                task_group="1",
+                node_id="spec_a:1",
+                touched_path="file.py",
+                status="completed",
+                input_tokens=8000,
+                output_tokens=3000,
+                duration_ms=20000,
+                created_at="2026-01-01T00:00:00",
+                run_id="run_1",
+                attempt=1,
+                cost=1.20,
+                model="claude-sonnet-4-6",
+                archetype="coder",
+                commit_sha="abc123",
+                error_message=None,
+                is_transport_error=False,
+            ),
+        )
+        update_run_totals(conn, "run_1", input_tokens=8000, output_tokens=3000, cost=1.20)
+
+        report = generate_status(plan_path=plan_path, db_conn=conn)
+        conn.close()
+
+        assert report.input_tokens == 8000, (
+            f"Expected 8000 input tokens from DB, got {report.input_tokens}. "
+            "load_state_from_db must not gate on plan_nodes being non-empty."
+        )
+        assert report.output_tokens == 3000
+        assert abs(report.estimated_cost - 1.20) < 0.01, (
+            f"Expected cost ~1.20 from DB, got {report.estimated_cost}. "
+            "Cost must not silently fall back to $0.00 when plan_nodes is empty."
+        )


### PR DESCRIPTION
## Summary

Removes the early-return guard in `load_state_from_db` that silently discarded all `session_outcomes` and `runs` data whenever `plan_nodes` was empty. The nightshift execution path writes sessions and run totals without populating `plan_nodes`, so `af status` and `af standup` were showing `$0.00` and zero token counts after nightshift runs even though real data existed in the DB.

Closes #379

## Changes

| File | Change |
|------|--------|
| `agent_fox/engine/state.py` | Remove `if not rows: return None` guard; update docstring to document the new contract |
| `tests/unit/engine/test_db_plan_state.py` | Two regression tests: empty plan_nodes with sessions, empty plan_nodes with run totals |
| `tests/unit/reporting/test_status.py` | End-to-end regression: generate_status shows real cost/tokens when plan_nodes is empty |

## Root Cause

`load_state_from_db` (state.py lines 251–252) unconditionally returned `None` when the `plan_nodes` table had zero rows. The function never reached the code that reads `session_outcomes` (per-session token counts, cost, model) or `runs` (aggregate totals). Callers in `status.py` and `standup.py` treated `state is None` as "no data" and fell through to zero-default branches.

## Fix

`load_state_from_db` now returns `None` only when `plan_nodes` cannot be queried at all (table missing or DB corrupt). An empty `plan_nodes` is valid — it becomes `node_states = {}`. The function always continues to load session history and run totals.

## Tests

- `test_load_state_from_db_empty_plan_nodes_loads_sessions` — verifies session_history is populated from session_outcomes even when plan_nodes is empty
- `test_load_state_from_db_empty_plan_nodes_loads_run_totals` — verifies run totals (total_input_tokens, total_cost) are loaded even when plan_nodes is empty
- `TestStatusEmptyPlanNodes.test_correct_cost_when_plan_nodes_empty` — end-to-end: generate_status returns correct tokens/cost from a DB where plan_nodes has no rows

## Verification

- All existing tests pass: ✅ (4603 → 4606 tests)
- New regression tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*