### PR TITLE
fix(state): decouple session/run loading from plan_nodes in load_state_from_db (fixes #379)

### DIFF
--- a/agent_fox/engine/state.py
+++ b/agent_fox/engine/state.py
@@ -239,7 +239,10 @@ def load_state_from_db(
 
     Loads node_states from plan_nodes, session history from
     session_outcomes, blocked reasons, and run totals. Returns None
-    if no plan data exists in the database.
+    only if the plan_nodes table cannot be queried (missing table or
+    corrupt DB). An empty plan_nodes table yields an ExecutionState
+    with node_states={} — session_outcomes and runs are always loaded
+    regardless of whether plan_nodes has any rows.
 
     Requirements: 105-REQ-5.3
     """
@@ -248,8 +251,8 @@ def load_state_from_db(
         rows = conn.sql("SELECT id, status FROM plan_nodes").fetchall()
     except Exception:
         return None
-    if not rows:
-        return None
+    # Empty plan_nodes is valid (nightshift path or pre-migration plan):
+    # continue loading session_outcomes and runs rather than returning None.
     node_states = {row[0]: row[1] for row in rows}
 
     # Load blocked reasons

--- a/tests/unit/engine/test_db_plan_state.py
+++ b/tests/unit/engine/test_db_plan_state.py
@@ -473,6 +473,86 @@ def test_incomplete_run_resume(db_conn: duckdb.DuckDBPyConnection) -> None:
     assert count == 1
 
 
+# -- Regression tests: issue #379 — empty plan_nodes must not block session/run loading ---
+
+
+def test_load_state_from_db_empty_plan_nodes_loads_sessions(
+    db_conn: duckdb.DuckDBPyConnection,
+) -> None:
+    """Regression #379: load_state_from_db returns session history even when plan_nodes is empty.
+
+    The nightshift path can populate session_outcomes without ever writing to
+    plan_nodes.  The old code returned None immediately when plan_nodes was
+    empty, silently discarding all session data.
+    """
+    from agent_fox.engine.state import SessionOutcomeRecord, load_state_from_db, record_session
+
+    # plan_nodes intentionally left empty (nightshift scenario)
+    assert db_conn.sql("SELECT count(*) FROM plan_nodes").fetchone()[0] == 0
+
+    # Insert a session outcome directly (as the engine result-handler would)
+    record_session(
+        db_conn,
+        SessionOutcomeRecord(
+            id="s_nightshift",
+            spec_name="spec_a",
+            task_group="1",
+            node_id="spec_a:1",
+            touched_path="foo.py",
+            status="completed",
+            input_tokens=12_000,
+            output_tokens=3_000,
+            duration_ms=8_000,
+            created_at="2026-01-01T12:00:00",
+            run_id="run_ns",
+            attempt=1,
+            cost=0.42,
+            model="claude-sonnet-4-6",
+            archetype="coder",
+            commit_sha="deadbeef",
+            error_message=None,
+            is_transport_error=False,
+        ),
+    )
+
+    state = load_state_from_db(db_conn)
+
+    # Must NOT return None — plan_nodes being empty is not an error
+    assert state is not None
+    assert state.node_states == {}
+
+    # Session history must be populated
+    assert len(state.session_history) == 1
+    session = state.session_history[0]
+    assert session.node_id == "spec_a:1"
+    assert session.input_tokens == 12_000
+    assert abs(session.cost - 0.42) < 1e-9
+
+
+def test_load_state_from_db_empty_plan_nodes_loads_run_totals(
+    db_conn: duckdb.DuckDBPyConnection,
+) -> None:
+    """Regression #379: load_state_from_db returns run totals even when plan_nodes is empty."""
+    from agent_fox.engine.state import create_run, load_state_from_db, update_run_totals
+
+    # plan_nodes intentionally left empty
+    assert db_conn.sql("SELECT count(*) FROM plan_nodes").fetchone()[0] == 0
+
+    create_run(db_conn, "run_ns", "hash_nightshift")
+    # update_run_totals accumulates — call three times to represent 3 sessions
+    update_run_totals(db_conn, "run_ns", input_tokens=20_000, output_tokens=4_000, cost=0.70)
+    update_run_totals(db_conn, "run_ns", input_tokens=15_000, output_tokens=3_000, cost=0.55)
+    update_run_totals(db_conn, "run_ns", input_tokens=15_000, output_tokens=3_000, cost=0.50)
+
+    state = load_state_from_db(db_conn)
+
+    assert state is not None
+    assert state.total_input_tokens == 50_000
+    assert state.total_output_tokens == 10_000
+    assert abs(state.total_cost - 1.75) < 1e-9
+    assert state.total_sessions == 3
+
+
 # -- Edge case tests: TS-105-E6 DB missing for af status ----------------------
 
 

--- a/tests/unit/reporting/test_status.py
+++ b/tests/unit/reporting/test_status.py
@@ -274,3 +274,99 @@ class TestStatusNoPlanFile:
             generate_status(plan_path=bad_plan)
 
         assert "plan" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Regression #379: empty plan_nodes must not zero-out token/cost reporting
+# ---------------------------------------------------------------------------
+
+
+class TestStatusEmptyPlanNodes:
+    """Regression #379: token counts and costs are loaded from session_outcomes/runs
+    even when plan_nodes is empty (nightshift path)."""
+
+    def test_correct_cost_when_plan_nodes_empty(
+        self,
+        tmp_plan_dir: Path,
+    ) -> None:
+        """generate_status shows real tokens/cost from DB when plan_nodes has no rows."""
+        import duckdb
+        from unittest.mock import patch
+
+        # Build a simple plan file (no DB plan, so plan_nodes stays empty)
+        nodes = {"spec_a:1": {"title": "Task 1"}}
+        plan_path = write_plan_file(tmp_plan_dir, nodes=nodes)
+
+        # Set up an in-memory DuckDB with the full schema but no plan_nodes rows
+        _SCHEMA = """
+        CREATE TABLE IF NOT EXISTS plan_nodes (
+            id VARCHAR PRIMARY KEY, spec_name VARCHAR NOT NULL,
+            group_number INTEGER NOT NULL, title VARCHAR NOT NULL,
+            body TEXT NOT NULL DEFAULT '', archetype VARCHAR NOT NULL DEFAULT 'coder',
+            mode VARCHAR, model_tier VARCHAR,
+            status VARCHAR NOT NULL DEFAULT 'pending', subtask_count INTEGER NOT NULL DEFAULT 0,
+            optional BOOLEAN NOT NULL DEFAULT FALSE, instances INTEGER NOT NULL DEFAULT 1,
+            sort_position INTEGER NOT NULL DEFAULT 0, blocked_reason VARCHAR,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE IF NOT EXISTS runs (
+            id VARCHAR PRIMARY KEY, plan_content_hash VARCHAR NOT NULL,
+            started_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            completed_at TIMESTAMP, status VARCHAR NOT NULL DEFAULT 'running',
+            total_input_tokens BIGINT NOT NULL DEFAULT 0,
+            total_output_tokens BIGINT NOT NULL DEFAULT 0,
+            total_cost DOUBLE NOT NULL DEFAULT 0.0,
+            total_sessions INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE IF NOT EXISTS session_outcomes (
+            id VARCHAR PRIMARY KEY, spec_name VARCHAR, task_group VARCHAR,
+            node_id VARCHAR, touched_path VARCHAR, status VARCHAR,
+            input_tokens INTEGER, output_tokens INTEGER, duration_ms INTEGER,
+            created_at TIMESTAMP, run_id VARCHAR, attempt INTEGER DEFAULT 1,
+            cost DOUBLE DEFAULT 0.0, model VARCHAR, archetype VARCHAR,
+            commit_sha VARCHAR, error_message TEXT, is_transport_error BOOLEAN DEFAULT FALSE
+        );
+        CREATE TABLE IF NOT EXISTS plan_meta (
+            id INTEGER PRIMARY KEY, content_hash VARCHAR NOT NULL,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            fast_mode BOOLEAN NOT NULL DEFAULT FALSE, filtered_spec VARCHAR,
+            version VARCHAR NOT NULL DEFAULT ''
+        );
+        CREATE TABLE IF NOT EXISTS audit_events (
+            id VARCHAR PRIMARY KEY, event_type VARCHAR NOT NULL,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            payload JSON
+        );
+        """
+        conn = duckdb.connect(":memory:")
+        conn.execute(_SCHEMA)
+
+        # plan_nodes intentionally left empty (nightshift scenario)
+        assert conn.sql("SELECT count(*) FROM plan_nodes").fetchone()[0] == 0
+
+        # Insert run totals directly (as the engine would after completing sessions)
+        conn.execute(
+            "INSERT INTO runs (id, plan_content_hash, total_input_tokens, "
+            "total_output_tokens, total_cost, total_sessions, status) "
+            "VALUES ('run_ns', 'hash_ns', 75000, 15000, 2.10, 5, 'completed')"
+        )
+
+        # Suppress the audit path (no audit_events rows) so the test exercises
+        # the state.total_* fallback branch in generate_status
+        with patch(
+            "agent_fox.reporting.status.build_status_report_from_audit",
+            return_value=None,
+        ), patch(
+            "agent_fox.graph.persistence._load_plan_from_db",
+            return_value=None,
+        ):
+            report = generate_status(plan_path=plan_path, db_conn=conn)
+
+        conn.close()
+
+        # The fix: state is no longer None when plan_nodes is empty,
+        # so token counts and cost come from the runs table
+        assert report.input_tokens == 75_000
+        assert report.output_tokens == 15_000
+        assert abs(report.estimated_cost - 2.10) < 0.01


### PR DESCRIPTION
## Summary

Removed the `if not rows: return None` early-exit in `load_state_from_db` that silently discarded all session history and run totals whenever `plan_nodes` was empty. The nightshift execution path can populate `session_outcomes` and `runs` without ever writing to `plan_nodes`, causing `af status` and `af standup` to display zero token counts and costs.

Closes #379

## Changes

| File | Change |
|------|--------|
| `agent_fox/engine/state.py` | Remove `if not rows: return None` guard; update docstring |
| `tests/unit/engine/test_db_plan_state.py` | Add two regression tests for empty plan_nodes |
| `tests/unit/reporting/test_status.py` | Add end-to-end regression test for generate_status with empty plan_nodes |

## Tests

- `test_load_state_from_db_empty_plan_nodes_loads_sessions` — session_history populated even when plan_nodes empty
- `test_load_state_from_db_empty_plan_nodes_loads_run_totals` — run totals loaded even when plan_nodes empty
- `TestStatusEmptyPlanNodes.test_correct_cost_when_plan_nodes_empty` — generate_status returns correct tokens/cost

## Verification

- All existing tests pass: ✅ (4603 → 4606)
- New regression tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*