### PR TITLE
fix(engine): resolve consolidation model from registry instead of hardcoded string (fixes #381)

### DIFF
--- a/agent_fox/engine/barrier.py
+++ b/agent_fox/engine/barrier.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from agent_fox.core.models import TIER_DEFAULTS, ModelTier
 from agent_fox.workspace.develop import _sync_develop_with_remote
 from agent_fox.workspace.git import run_git
 from agent_fox.workspace.merge_lock import MergeLock
@@ -236,7 +237,7 @@ async def run_sync_barrier_sequence(
                     knowledge_db_conn,
                     repo_root,
                     new_completed,
-                    model="claude-3-5-haiku-20241022",
+                    model=TIER_DEFAULTS[ModelTier.SIMPLE],
                     sink_dispatcher=sink_dispatcher,
                 )
                 consolidated_specs.update(new_completed)

--- a/agent_fox/engine/engine.py
+++ b/agent_fox/engine/engine.py
@@ -33,7 +33,7 @@ from agent_fox.core.config import (
     load_config,
 )
 from agent_fox.core.errors import ConfigError, PlanError
-from agent_fox.core.models import content_hash
+from agent_fox.core.models import TIER_DEFAULTS, ModelTier, content_hash
 from agent_fox.engine.assessment import AssessmentManager
 from agent_fox.engine.audit_helpers import emit_audit_event
 from agent_fox.engine.barrier import _count_node_status, run_sync_barrier_sequence
@@ -622,7 +622,7 @@ class Orchestrator:
                             self._knowledge_db_conn,
                             self._plan_path.parent,
                             remaining,
-                            model="claude-3-5-haiku-20241022",
+                            model=TIER_DEFAULTS[ModelTier.SIMPLE],
                             sink_dispatcher=self._sink,
                             run_id=self._run_id,
                         )

--- a/tests/unit/engine/test_consolidation_barrier.py
+++ b/tests/unit/engine/test_consolidation_barrier.py
@@ -111,6 +111,45 @@ class TestBarrierTriggersConsolidation:
         assert passed_specs is not None
         assert "spec_a" in passed_specs
 
+    @pytest.mark.asyncio
+    async def test_barrier_uses_registry_model(
+        self, entity_conn: duckdb.DuckDBPyConnection, tmp_path: Path
+    ) -> None:
+        """Barrier passes registry SIMPLE model, not a hardcoded string."""
+        from agent_fox.core.models import TIER_DEFAULTS, ModelTier
+
+        state = _make_minimal_barrier_state({"task_a": "completed"})
+        mock_consolidation = AsyncMock(return_value=_make_zero_consolidation_result())
+        completed_specs_fn = MagicMock(return_value={"spec_a"})
+        consolidated_specs: set[str] = set()
+
+        with patch("agent_fox.engine.barrier.run_consolidation", mock_consolidation):
+            await run_sync_barrier_sequence(
+                state=state,
+                sync_interval=1,
+                repo_root=tmp_path,
+                emit_audit=MagicMock(),
+                specs_dir=None,
+                hot_load_enabled=False,
+                hot_load_fn=AsyncMock(),
+                sync_plan_fn=MagicMock(),
+                barrier_callback=None,
+                knowledge_db_conn=entity_conn,
+                sink_dispatcher=None,
+                completed_specs_fn=completed_specs_fn,
+                consolidated_specs=consolidated_specs,
+            )
+
+        assert mock_consolidation.called
+        call_kwargs = mock_consolidation.call_args
+        passed_model = call_kwargs.kwargs.get("model") or (
+            call_kwargs.args[3] if call_kwargs.args and len(call_kwargs.args) > 3 else None
+        )
+        expected_model = TIER_DEFAULTS[ModelTier.SIMPLE]
+        assert passed_model == expected_model, (
+            f"Barrier must use registry model '{expected_model}', got '{passed_model}'"
+        )
+
 
 # ---------------------------------------------------------------------------
 # TS-96-22: End-of-run consolidation for remaining specs


### PR DESCRIPTION
## Summary

Replace the obsolete hardcoded model string `claude-3-5-haiku-20241022` in both consolidation callsites with `TIER_DEFAULTS[ModelTier.SIMPLE]` from the model registry, fixing Vertex AI 404 failures in the knowledge consolidation pipeline.

Closes #381

## Changes

| File | Change |
|------|--------|
| `agent_fox/engine/barrier.py` | Import `TIER_DEFAULTS, ModelTier` from `core.models`; use `TIER_DEFAULTS[ModelTier.SIMPLE]` instead of hardcoded model ID |
| `agent_fox/engine/engine.py` | Extend `core.models` import; use `TIER_DEFAULTS[ModelTier.SIMPLE]` instead of hardcoded model ID |
| `tests/unit/engine/test_consolidation_barrier.py` | Regression test: `test_barrier_uses_registry_model` verifies the barrier passes the registry model to `run_consolidation` |

## Tests

- `TestBarrierTriggersConsolidation::test_barrier_uses_registry_model`: asserts `model` kwarg passed by barrier equals `TIER_DEFAULTS[ModelTier.SIMPLE]` (`claude-haiku-4-5`)

## Verification

- All existing tests pass: ✅ (4610 → 4611)
- New regression test passes: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*