### PR TITLE
fix(security): block shell variable expansion to prevent secret leakage (fixes #345)

### DIFF
--- a/agent_fox/security/security.py
+++ b/agent_fox/security/security.py
@@ -158,12 +158,13 @@ def extract_command_name(command_string: str) -> str:
 # Matched against the raw command string before allowlist checking.
 _SHELL_OPERATOR_PATTERN = re.compile(
     r"""
-      \|          # pipe (including ||)
-    | ;           # command separator
-    | &&          # logical AND chaining
-    | `           # backtick subshell
-    | \$\(        # $() subshell
-    | [<>]        # redirects (>, <, >>, etc.)
+      \|              # pipe (including ||)
+    | ;               # command separator
+    | &&              # logical AND chaining
+    | `               # backtick subshell
+    | \$\(            # $() subshell
+    | \$[a-zA-Z_{]   # variable expansion ($VAR, ${VAR}) — prevents secret leakage
+    | [<>]            # redirects (>, <, >>, etc.)
     """,
     re.VERBOSE,
 )

--- a/tests/property/security/test_security_props.py
+++ b/tests/property/security/test_security_props.py
@@ -106,6 +106,55 @@ class TestAllowlistEnforcementCompleteness:
         assert allowed == expected, f"Command '{command}' allowed={allowed} but expected allowed={expected}"
 
 
+class TestShellVariableExpansionBlockedProperty:
+    """Property: any command containing $VAR or ${VAR} is always blocked.
+
+    Issue #345: variable expansion was missing from _SHELL_OPERATOR_PATTERN.
+    """
+
+    # Variable names must start with an ASCII letter or underscore (POSIX).
+    # The fix covers $[a-zA-Z_{] — numeric positional params ($0, $1) and
+    # non-ASCII letters are intentionally out of scope.
+    _var_first_char = st.sampled_from(
+        list("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_")
+    )
+    _var_rest = st.text(
+        alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_",
+        min_size=0,
+        max_size=19,
+    )
+
+    @given(
+        cmd=st.sampled_from(sorted(DEFAULT_ALLOWLIST)),
+        first=_var_first_char,
+        rest=_var_rest,
+    )
+    @settings(max_examples=60)
+    def test_dollar_var_always_blocked(self, cmd: str, first: str, rest: str) -> None:
+        """Any allowlisted command with $VAR (letter/underscore-led) is rejected."""
+        var = first + rest
+        command = f"{cmd} ${var}"
+        result = check_shell_operators(command)
+        assert result is not None, (
+            f"Expected check_shell_operators to reject '{command}' containing variable expansion"
+        )
+
+    @given(
+        cmd=st.sampled_from(sorted(DEFAULT_ALLOWLIST)),
+        first=_var_first_char,
+        rest=_var_rest,
+    )
+    @settings(max_examples=60)
+    def test_braced_dollar_var_always_blocked(self, cmd: str, first: str, rest: str) -> None:
+        """Any allowlisted command with ${VAR} (letter/underscore-led) is rejected."""
+        var = first + rest
+        command = f"{cmd} ${{{var}}}"
+        result = check_shell_operators(command)
+        assert result is not None, (
+            f"Expected check_shell_operators to reject '{command}' containing braced variable expansion"
+        )
+
+
 class TestDefaultAllowlistStability:
     """TS-06-P2: Default allowlist stability.
 

--- a/tests/unit/security/test_security.py
+++ b/tests/unit/security/test_security.py
@@ -431,6 +431,74 @@ class TestShellOperatorsBypassBlocked:
         assert allowed is True
 
 
+class TestShellVariableExpansionBlocked:
+    """Regression tests for issue #345: $VAR / ${VAR} bypasses operator filter.
+
+    Shell variable expansion must be treated as a shell operator because it
+    can leak secrets from the environment (e.g. $ANTHROPIC_API_KEY, ${PATH}).
+    """
+
+    def test_simple_var_expansion_blocked(self) -> None:
+        """$VAR expansion is detected and blocked."""
+        result = check_shell_operators("echo $HOME")
+        assert result is not None
+        assert "shell operator" in result.lower()
+
+    def test_braced_var_expansion_blocked(self) -> None:
+        """${VAR} braced expansion is detected and blocked."""
+        result = check_shell_operators("echo ${PATH}")
+        assert result is not None
+        assert "shell operator" in result.lower()
+
+    def test_api_key_leak_blocked(self) -> None:
+        """echo $ANTHROPIC_API_KEY is blocked (secret exfiltration)."""
+        result = check_shell_operators("echo $ANTHROPIC_API_KEY")
+        assert result is not None
+
+    def test_curl_secret_url_blocked(self) -> None:
+        """curl $SECRET_URL is blocked (secret in variable)."""
+        result = check_shell_operators("curl $SECRET_URL")
+        assert result is not None
+
+    def test_braced_api_key_leak_blocked(self) -> None:
+        """echo ${ANTHROPIC_API_KEY} (braced form) is blocked."""
+        result = check_shell_operators("echo ${ANTHROPIC_API_KEY}")
+        assert result is not None
+
+    def test_underscore_var_blocked(self) -> None:
+        """$_VAR (underscore-prefixed variable) is blocked."""
+        result = check_shell_operators("echo $_MY_SECRET")
+        assert result is not None
+
+    def test_var_expansion_end_to_end_blocked(self) -> None:
+        """End-to-end: echo $ANTHROPIC_API_KEY is blocked by check_command_allowed."""
+        allowed, msg = check_command_allowed("echo $ANTHROPIC_API_KEY", DEFAULT_ALLOWLIST)
+        assert allowed is False
+        assert "shell operator" in msg.lower()
+
+    def test_braced_var_end_to_end_blocked(self) -> None:
+        """End-to-end: curl ${SECRET_URL} is blocked by check_command_allowed."""
+        allowed, msg = check_command_allowed("curl ${SECRET_URL}", DEFAULT_ALLOWLIST)
+        assert allowed is False
+
+    def test_simple_command_without_dollar_still_allowed(self) -> None:
+        """Commands without $ are unaffected by the new pattern."""
+        assert check_shell_operators("echo hello") is None
+
+    def test_git_log_format_still_allowed(self) -> None:
+        """git log --format=%H (percent, not dollar) is still allowed."""
+        assert check_shell_operators("git log --format=%H") is None
+
+    def test_hook_blocks_var_expansion(self) -> None:
+        """Pre-tool-use hook blocks $VAR expansion in Bash tool."""
+        hook = make_pre_tool_use_hook(SecurityConfig())
+        result = hook(
+            tool_name="Bash",
+            tool_input={"command": "echo $ANTHROPIC_API_KEY"},
+        )
+        assert result["decision"] == "block"
+
+
 class TestPreToolUseHookShellOperators:
     """Verify the pre-tool-use hook blocks shell operator bypass attempts."""
 


### PR DESCRIPTION
## Summary

`$VAR` and `${VAR}` syntax was missing from `_SHELL_OPERATOR_PATTERN`, allowing commands like `echo $ANTHROPIC_API_KEY` to bypass the shell operator check and leak environment secrets. Adds `\$[a-zA-Z_{]` to the pattern so all named variable expansions are blocked before allowlist checking.

Closes #345

## Changes

| File | Change |
|------|--------|
| `agent_fox/security/security.py` | Added `\$[a-zA-Z_{]` alternative to `_SHELL_OPERATOR_PATTERN` |
| `tests/unit/security/test_security.py` | Added `TestShellVariableExpansionBlocked` (11 regression tests) |
| `tests/property/security/test_security_props.py` | Added `TestShellVariableExpansionBlockedProperty` (2 Hypothesis property tests) |

## Tests

- `TestShellVariableExpansionBlocked` — covers `$HOME`, `${PATH}`, `$ANTHROPIC_API_KEY`, `${SECRET_URL}`, `$_MY_SECRET`, end-to-end hook blocking, and non-regression of safe commands
- `TestShellVariableExpansionBlockedProperty` — Hypothesis property tests verifying all ASCII letter/underscore-prefixed `$VAR` and `${VAR}` forms are always blocked

## Verification

- All existing tests pass: ✅ (4611 → 4624, no regressions)
- New tests pass: ✅ (13 new tests)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*