### PR TITLE
fix(security): reject symlinks in steering, doc, and config loading (fixes #350)

### DIFF
--- a/agent_fox/core/config.py
+++ b/agent_fox/core/config.py
@@ -936,6 +936,11 @@ def load_config(path: Path | None = None) -> AgentFoxConfig:
     if path is None or not path.exists():
         return AgentFoxConfig()
 
+    # Security: reject symlinks to prevent path traversal (CWE-59)
+    if path.is_symlink():
+        logger.warning("Config file is a symlink; skipping for security")
+        return AgentFoxConfig()
+
     # Read and parse TOML
     raw = path.read_text(encoding="utf-8")
 

--- a/agent_fox/knowledge/doc_mining.py
+++ b/agent_fox/knowledge/doc_mining.py
@@ -88,6 +88,10 @@ def _collect_doc_files(project_root: Path) -> list[Path]:
     # Root-level docs: README.md, CONTRIBUTING.md, CHANGELOG.md
     for name in ("README.md", "CONTRIBUTING.md", "CHANGELOG.md"):
         candidate = project_root / name
+        # Security: reject symlinks to prevent path traversal (CWE-59)
+        if candidate.is_symlink():
+            logger.warning("Skipping root-level symlink for security: %s", candidate)
+            continue
         if candidate.is_file():
             files.append(candidate)
 
@@ -96,7 +100,15 @@ def _collect_doc_files(project_root: Path) -> list[Path]:
     if docs_dir.is_dir():
         adr_dir = docs_dir / "adr"
         errata_dir = docs_dir / "errata"
+        resolved_docs_dir = docs_dir.resolve()
         for md_file in sorted(docs_dir.rglob("*.md")):
+            # Security: reject symlinks that escape the docs/ boundary (CWE-59)
+            if md_file.is_symlink():
+                try:
+                    md_file.resolve().relative_to(resolved_docs_dir)
+                except ValueError:
+                    logger.warning("Skipping symlink pointing outside docs/: %s", md_file)
+                    continue
             # Skip files inside excluded subdirectories
             try:
                 md_file.relative_to(adr_dir)

--- a/agent_fox/session/steering.py
+++ b/agent_fox/session/steering.py
@@ -37,6 +37,11 @@ def load_steering(project_root: Path) -> str | None:
     """
     steering_path = project_root / _STEERING_PATH
 
+    # Security: reject symlinks to prevent path traversal (CWE-59)
+    if steering_path.is_symlink():
+        logger.warning("Steering file is a symlink; skipping for security")
+        return None
+
     # 64-REQ-2.3: Skip silently when file is absent
     if not steering_path.exists():
         logger.debug("Steering file not found at %s, skipping", steering_path)

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -130,3 +130,45 @@ class TestConfigUnrecognizedKeys:
         config = load_config(path=config_file)
 
         assert config.orchestrator.parallel == 2
+
+
+class TestConfigSymlinkRejection:
+    """Security: load_config() rejects symlinked config files (CWE-59 mitigation)."""
+
+    def test_symlink_config_returns_defaults(self, tmp_path: Path) -> None:
+        """load_config() returns defaults when config path is a symlink."""
+        target = tmp_path / "sensitive.toml"
+        target.write_text('[orchestrator]\nparallel = 99\n')
+        symlink = tmp_path / "config.toml"
+        symlink.symlink_to(target)
+
+        config = load_config(path=symlink)
+
+        # Falls back to defaults, does NOT load the symlink target
+        assert isinstance(config, AgentFoxConfig)
+        assert config.orchestrator.parallel == 2  # default, not 99
+
+    def test_symlink_config_logs_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """load_config() logs a warning when config path is a symlink."""
+        import logging
+
+        target = tmp_path / "sensitive.toml"
+        target.write_text("")
+        symlink = tmp_path / "config.toml"
+        symlink.symlink_to(target)
+
+        with caplog.at_level(logging.WARNING):
+            load_config(path=symlink)
+
+        assert any(record.levelno >= logging.WARNING for record in caplog.records)
+
+    def test_non_symlink_config_loads_normally(self, tmp_path: Path) -> None:
+        """A regular (non-symlink) config file still loads correctly."""
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("[orchestrator]\nparallel = 4\n")
+
+        config = load_config(path=config_file)
+
+        assert config.orchestrator.parallel == 4

--- a/tests/unit/knowledge/test_doc_mining.py
+++ b/tests/unit/knowledge/test_doc_mining.py
@@ -121,6 +121,47 @@ class TestCollectDocFiles:
         files = _collect_doc_files(tmp_path)
         assert files == []
 
+    def test_excludes_symlink_escaping_docs_boundary(self, tmp_path: Path) -> None:
+        """Symlink inside docs/ that points outside the directory is excluded (CWE-59)."""
+        # Create a target file outside docs/
+        sensitive = tmp_path / "sensitive.txt"
+        sensitive.write_text("secret")
+
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        symlink = docs / "evil.md"
+        symlink.symlink_to(sensitive)
+
+        files = _collect_doc_files(tmp_path)
+        assert symlink not in files
+
+    def test_excludes_symlink_outside_from_root_level_candidates(self, tmp_path: Path) -> None:
+        """Root-level README.md symlink pointing outside project is excluded (CWE-59)."""
+        target = tmp_path / "outside_dir"
+        target.mkdir()
+        sensitive = target / "secret.md"
+        sensitive.write_text("secret content")
+
+        project = tmp_path / "project"
+        project.mkdir()
+        readme_link = project / "README.md"
+        readme_link.symlink_to(sensitive)
+
+        files = _collect_doc_files(project)
+        assert readme_link not in files
+
+    def test_allows_symlink_within_docs_boundary(self, tmp_path: Path) -> None:
+        """Symlink inside docs/ that resolves within docs/ is allowed."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        real_file = docs / "real.md"
+        real_file.write_text("real content")
+        symlink = docs / "link.md"
+        symlink.symlink_to(real_file)
+
+        files = _collect_doc_files(tmp_path)
+        assert symlink in files
+
 
 class TestMineDocsWithLLM:
     """TS-101-25: mine_docs_with_llm creates facts from LLM output.

--- a/tests/unit/session/test_steering.py
+++ b/tests/unit/session/test_steering.py
@@ -194,3 +194,58 @@ class TestLoadSteeringHandlesUnreadableFile:
             load_steering(tmp_path)
 
         assert any(record.levelno >= logging.WARNING for record in caplog.records), "Expected a warning to be logged"
+
+
+# ---------------------------------------------------------------------------
+# Security: symlink rejection (Issue #350, CWE-59)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSteeringRejectsSymlink:
+    """load_steering() skips steering.md when it is a symlink (CWE-59 mitigation)."""
+
+    def test_returns_none_for_symlink(self, tmp_path: Path) -> None:
+        """load_steering() returns None when steering.md is a symlink."""
+        from agent_fox.session.prompt import load_steering
+
+        # Create a target file outside the project
+        target = tmp_path / "sensitive_file.txt"
+        target.write_text("sensitive content")
+
+        specs_dir = tmp_path / ".specs"
+        specs_dir.mkdir()
+        symlink = specs_dir / "steering.md"
+        symlink.symlink_to(target)
+
+        result = load_steering(tmp_path)
+        assert result is None
+
+    def test_logs_warning_for_symlink(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """load_steering() logs a warning when steering.md is a symlink."""
+        from agent_fox.session.prompt import load_steering
+
+        target = tmp_path / "sensitive_file.txt"
+        target.write_text("sensitive content")
+
+        specs_dir = tmp_path / ".specs"
+        specs_dir.mkdir()
+        symlink = specs_dir / "steering.md"
+        symlink.symlink_to(target)
+
+        with caplog.at_level(logging.WARNING):
+            load_steering(tmp_path)
+
+        assert any(record.levelno >= logging.WARNING for record in caplog.records)
+
+    def test_non_symlink_still_loads(self, tmp_path: Path) -> None:
+        """Normal (non-symlink) steering.md continues to load correctly."""
+        from agent_fox.session.prompt import load_steering
+
+        specs_dir = tmp_path / ".specs"
+        specs_dir.mkdir()
+        (specs_dir / "steering.md").write_text("Always add type hints.")
+
+        result = load_steering(tmp_path)
+        assert result == "Always add type hints."


### PR DESCRIPTION
## Summary

Adds `is_symlink()` guards to the three file-loading paths identified in issue #350 as vulnerable to CWE-59 path traversal via symlink attacks.

Closes #350

## Changes

| File | Change |
|------|--------|
| `agent_fox/session/steering.py` | Rejects `.specs/steering.md` if it is a symlink; logs warning, returns `None` |
| `agent_fox/knowledge/doc_mining.py` | Rejects root-level symlinked candidates; rejects `docs/` symlinks that escape the directory boundary (intra-docs symlinks are allowed) |
| `agent_fox/core/config.py` | Rejects `.agent-fox/config.toml` if it is a symlink; logs warning, falls back to defaults |
| `tests/unit/session/test_steering.py` | 3 new tests: symlink rejected, warning logged, normal file loads |
| `tests/unit/knowledge/test_doc_mining.py` | 3 new tests: escaping symlink excluded, root symlink excluded, intra-docs symlink allowed |
| `tests/unit/core/test_config.py` | 3 new tests: symlink returns defaults, warning logged, normal file loads |

## Tests

- `tests/unit/session/test_steering.py::TestLoadSteeringRejectsSymlink` — 3 tests
- `tests/unit/knowledge/test_doc_mining.py::TestCollectDocFiles` — 3 new tests
- `tests/unit/core/test_config.py::TestConfigSymlinkRejection` — 3 tests

## Verification

- All existing tests pass: ✅ (4624 → 4633)
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*