### PR TITLE
fix(init): commit profiles to git and update .gitignore (fixes #389)

### DIFF
--- a/agent_fox/cli/init.py
+++ b/agent_fox/cli/init.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+import subprocess
 from pathlib import Path
 
 import click
@@ -55,6 +56,21 @@ def init_profiles(project_dir: Path) -> list[Path]:
             continue
         shutil.copy2(src_file, dest_file)
         created.append(dest_file)
+
+    if created:
+        # Stage the newly created profiles in git.  The .gitignore exception
+        # !.agent-fox/profiles/* ensures git accepts the files without --force.
+        try:
+            subprocess.run(
+                ["git", "add", *[str(p) for p in created]],
+                cwd=project_dir,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            logger.debug("Staged %d profile(s) in git", len(created))
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            logger.warning("Could not git add profiles: %s", exc)
 
     return created
 

--- a/agent_fox/workspace/init_project.py
+++ b/agent_fox/workspace/init_project.py
@@ -29,7 +29,8 @@ _GITIGNORE_ENTRIES = [
     "# agent-fox",
     ".agent-fox/*",
     "!.agent-fox/config.toml",
-    "!.agent-fox/memory.jsonl",
+    "!.agent-fox/profiles/",
+    "!.agent-fox/profiles/*",
     ".claude/worktrees/",
 ]
 
@@ -284,14 +285,31 @@ def _ensure_seed_files(project_root: Path) -> None:
 
     Creates .agent-fox/memory.jsonl and docs/memory.md if they do not
     already exist. Idempotent — existing files are never overwritten.
+
+    memory.jsonl is added to git with ``--force`` because ``.agent-fox/*``
+    in .gitignore would otherwise exclude it.  The operation is best-effort:
+    failures are logged as warnings so that init still succeeds in
+    environments where git is unavailable.
     """
     agent_fox_dir = project_root / ".agent-fox"
 
-    for name in ("memory.jsonl",):
-        path = agent_fox_dir / name
-        if not path.exists():
-            path.touch()
-            logger.debug("Created seed file %s", path)
+    memory_jsonl = agent_fox_dir / "memory.jsonl"
+    if not memory_jsonl.exists():
+        memory_jsonl.touch()
+        logger.debug("Created seed file %s", memory_jsonl)
+
+    # Force-add memory.jsonl so it is tracked even though .agent-fox/* ignores it.
+    try:
+        subprocess.run(
+            ["git", "add", "--force", str(memory_jsonl)],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        logger.debug("Staged %s in git", memory_jsonl)
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        logger.warning("Could not git add %s: %s", memory_jsonl, exc)
 
     docs_dir = project_root / "docs"
     docs_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -117,12 +117,27 @@ class TestInitGitignore:
         gitignore = (tmp_git_repo / ".gitignore").read_text()
         assert "!.agent-fox/state.jsonl" not in gitignore
 
-    def test_gitignore_excludes_memory(self, cli_runner: CliRunner, tmp_git_repo: Path) -> None:
-        """init adds !.agent-fox/memory.jsonl exception to .gitignore."""
+    def test_gitignore_does_not_add_memory_exception(self, cli_runner: CliRunner, tmp_git_repo: Path) -> None:
+        """init does NOT add !.agent-fox/memory.jsonl exception to .gitignore.
+
+        memory.jsonl is tracked via git add --force, not a gitignore exception.
+        """
         cli_runner.invoke(main, ["init"])
 
         gitignore = (tmp_git_repo / ".gitignore").read_text()
-        assert "!.agent-fox/memory.jsonl" in gitignore
+        assert "!.agent-fox/memory.jsonl" not in gitignore
+
+    def test_gitignore_excludes_profiles_dir(self, cli_runner: CliRunner, tmp_git_repo: Path) -> None:
+        """init adds both !.agent-fox/profiles/ and !.agent-fox/profiles/* to .gitignore.
+
+        Two entries are needed: one to un-ignore the directory itself and one
+        to un-ignore files within it, because .agent-fox/* ignores the directory.
+        """
+        cli_runner.invoke(main, ["init"])
+
+        gitignore = (tmp_git_repo / ".gitignore").read_text()
+        assert "!.agent-fox/profiles/" in gitignore
+        assert "!.agent-fox/profiles/*" in gitignore
 
     def test_gitignore_contains_claude_worktrees(self, cli_runner: CliRunner, tmp_git_repo: Path) -> None:
         """init adds .claude/worktrees/ to .gitignore."""
@@ -130,6 +145,39 @@ class TestInitGitignore:
 
         gitignore = (tmp_git_repo / ".gitignore").read_text()
         assert ".claude/worktrees/" in gitignore
+
+
+class TestInitGitTracking:
+    """Init stages files in git so they are tracked from the start."""
+
+    def test_init_stages_memory_jsonl(self, cli_runner: CliRunner, tmp_git_repo: Path) -> None:
+        """init force-adds .agent-fox/memory.jsonl to git index."""
+        cli_runner.invoke(main, ["init"])
+
+        result = subprocess.run(
+            ["git", "ls-files", ".agent-fox/memory.jsonl"],
+            cwd=tmp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert ".agent-fox/memory.jsonl" in result.stdout
+
+    def test_init_profiles_stages_profiles(self, cli_runner: CliRunner, tmp_git_repo: Path) -> None:
+        """init --profiles adds copied profile files to git index."""
+        # First init to set up gitignore with !.agent-fox/profiles/*
+        cli_runner.invoke(main, ["init"])
+
+        from agent_fox.cli.init import init_profiles
+
+        init_profiles(project_dir=tmp_git_repo)
+
+        result = subprocess.run(
+            ["git", "ls-files", ".agent-fox/profiles/"],
+            cwd=tmp_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert ".agent-fox/profiles/" in result.stdout or "coder.md" in result.stdout
 
 
 class TestInitSeedFiles:


### PR DESCRIPTION
## Summary

- Replace the `!.agent-fox/memory.jsonl` gitignore exception with a `git add --force` call so memory.jsonl is tracked without a gitignore entry.
- Add `!.agent-fox/profiles/` and `!.agent-fox/profiles/*` gitignore entries so the profiles directory and its contents are not excluded by `.agent-fox/*`.
- Run `git add` on newly copied profile files in `init_profiles()` so they are staged immediately.

Closes #389

## Changes

| File | Change |
|------|--------|
| `agent_fox/workspace/init_project.py` | Update `_GITIGNORE_ENTRIES`; add `git add --force` in `_ensure_seed_files` |
| `agent_fox/cli/init.py` | Add `import subprocess`; run `git add` for copied profiles in `init_profiles()` |
| `tests/integration/test_init.py` | Update memory gitignore test; add profiles gitignore test; add `TestInitGitTracking` class |

## Tests

- `TestInitGitTracking::test_init_stages_memory_jsonl` — verifies memory.jsonl is in `git ls-files` after init
- `TestInitGitTracking::test_init_profiles_stages_profiles` — verifies profiles are in `git ls-files` after `init_profiles()`
- `TestInitGitignore::test_gitignore_excludes_profiles_dir` — verifies both gitignore exceptions for profiles directory

## Verification

- All existing tests pass: ✅
- New tests pass: ✅ (3 new tests, 4651 total)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*