### PR TITLE
refactor(archetypes): replace unsafe **dict unpacking with explicit named args (fixes #400)

### DIFF
--- a/agent_fox/archetypes.py
+++ b/agent_fox/archetypes.py
@@ -174,7 +174,7 @@ def resolve_effective_config(
         )
         return entry
 
-    # Build override kwargs: only apply non-None ModeConfig fields.
+    # Apply non-None ModeConfig fields as explicit named overrides.
     # ModeConfig field names map to ArchetypeEntry field names as follows:
     #   model_tier      -> default_model_tier
     #   max_turns       -> default_max_turns
@@ -183,23 +183,22 @@ def resolve_effective_config(
     #   allowlist       -> default_allowlist
     #   injection       -> injection
     #   retry_predecessor -> retry_predecessor
-    overrides: dict[str, object] = {}
-    if mode_cfg.injection is not None:
-        overrides["injection"] = mode_cfg.injection
-    if mode_cfg.allowlist is not None:
-        overrides["default_allowlist"] = mode_cfg.allowlist
-    if mode_cfg.model_tier is not None:
-        overrides["default_model_tier"] = mode_cfg.model_tier
-    if mode_cfg.max_turns is not None:
-        overrides["default_max_turns"] = mode_cfg.max_turns
-    if mode_cfg.thinking_mode is not None:
-        overrides["default_thinking_mode"] = mode_cfg.thinking_mode
-    if mode_cfg.thinking_budget is not None:
-        overrides["default_thinking_budget"] = mode_cfg.thinking_budget
-    if mode_cfg.retry_predecessor is not None:
-        overrides["retry_predecessor"] = mode_cfg.retry_predecessor
-
-    return dataclasses.replace(entry, **overrides)
+    return dataclasses.replace(
+        entry,
+        injection=mode_cfg.injection if mode_cfg.injection is not None else entry.injection,
+        default_allowlist=mode_cfg.allowlist if mode_cfg.allowlist is not None else entry.default_allowlist,
+        default_model_tier=mode_cfg.model_tier if mode_cfg.model_tier is not None else entry.default_model_tier,
+        default_max_turns=mode_cfg.max_turns if mode_cfg.max_turns is not None else entry.default_max_turns,
+        default_thinking_mode=(
+            mode_cfg.thinking_mode if mode_cfg.thinking_mode is not None else entry.default_thinking_mode
+        ),
+        default_thinking_budget=(
+            mode_cfg.thinking_budget if mode_cfg.thinking_budget is not None else entry.default_thinking_budget
+        ),
+        retry_predecessor=(
+            mode_cfg.retry_predecessor if mode_cfg.retry_predecessor is not None else entry.retry_predecessor
+        ),
+    )
 
 
 def _resolve_custom_preset(


### PR DESCRIPTION
## Summary

Replaces the `overrides: dict[str, object]` accumulation + `**overrides` unpacking in `resolve_effective_config()` with a single `dataclasses.replace()` call using explicit named keyword arguments. Each argument uses a conditional expression to apply the `ModeConfig` value when non-`None`, or inherit from the base entry otherwise.

Closes #400

## Changes

| File | Change |
|------|--------|
| `agent_fox/archetypes.py` | Remove `overrides` dict and `**dict` unpacking; use explicit named args in `dataclasses.replace()` |

## Tests

- All existing tests in `tests/unit/core/test_archetype_modes.py` cover every field override and inheritance case — no new tests needed as behaviour is unchanged.

## Verification

- All existing tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*