### PR TITLE
feat(logging): add --trace flag to gate bulk AI payload dumps (fixes #410)

### DIFF
--- a/agent_fox/cli/app.py
+++ b/agent_fox/cli/app.py
@@ -77,6 +77,12 @@ class BannerGroup(click.Group):
 @click.option("--verbose", "-v", is_flag=True, help="Enable debug logging")
 @click.option("--quiet", "-q", is_flag=True, help="Suppress info messages")
 @click.option(
+    "--trace",
+    is_flag=True,
+    default=False,
+    help="Enable trace logging (includes bulk AI prompt/response payloads; implies --verbose)",
+)
+@click.option(
     "--json",
     "json_mode",
     is_flag=True,
@@ -84,7 +90,7 @@ class BannerGroup(click.Group):
     help="Switch to structured JSON I/O mode",
 )
 @click.pass_context
-def main(ctx: click.Context, verbose: bool, quiet: bool, json_mode: bool) -> None:
+def main(ctx: click.Context, verbose: bool, quiet: bool, trace: bool, json_mode: bool) -> None:
     """agent-fox: autonomous coding-agent orchestrator."""
     ctx.ensure_object(dict)
 
@@ -92,15 +98,16 @@ def main(ctx: click.Context, verbose: bool, quiet: bool, json_mode: bool) -> Non
     ctx.obj["json"] = json_mode
 
     # In JSON mode, suppress warning-level log output so it doesn't pollute
-    # the structured JSON stdout stream. Verbose flag overrides this.
-    effective_quiet = quiet or (json_mode and not verbose)
-    setup_logging(verbose=verbose, quiet=effective_quiet)
+    # the structured JSON stdout stream. Verbose/trace flags override this.
+    effective_quiet = quiet or (json_mode and not verbose and not trace)
+    setup_logging(verbose=verbose, quiet=effective_quiet, trace=trace)
 
     config = load_config(Path(".agent-fox/config.toml"))
 
     ctx.obj["config"] = config
     ctx.obj["verbose"] = verbose
     ctx.obj["quiet"] = quiet
+    ctx.obj["trace"] = trace
 
     # 14-REQ-4.1: render banner on every invocation (suppressed by --quiet)
     # 23-REQ-2.1: suppress banner in JSON mode

--- a/agent_fox/core/logging.py
+++ b/agent_fox/core/logging.py
@@ -1,8 +1,14 @@
 """Logging configuration for agent-fox.
 
 Configures Python's logging module with a consistent format and
-level control via --verbose and --quiet flags. Uses named loggers
-per module for component-based log filtering.
+level control via --verbose, --trace, and --quiet flags. Uses named
+loggers per module for component-based log filtering.
+
+Verbosity tiers (highest to lowest detail):
+  TRACE (5)  -- bulk AI prompt/response payloads (--trace)
+  DEBUG (10) -- detailed per-step debug info (--verbose)
+  WARNING    -- default level (omit --verbose / --trace)
+  ERROR      -- errors only (--quiet)
 
 When a Rich Live display is active (e.g. the progress spinner),
 log messages are routed through Rich's console so they appear
@@ -20,6 +26,17 @@ if TYPE_CHECKING:
     from rich.console import Console
 
 _LOG_FORMAT = "[%(levelname)s] %(name)s: %(message)s"
+
+# ---------------------------------------------------------------------------
+# TRACE level — one tier below DEBUG, for bulk AI payload dumps
+# ---------------------------------------------------------------------------
+
+#: Custom log level for AI prompt/response payloads.  Sits below DEBUG (10)
+#: so that ``--verbose`` (DEBUG) does not emit these multi-KB blobs.
+#: Only activated when ``--trace`` is passed to the CLI.
+TRACE: int = logging.DEBUG - 5  # = 5
+
+logging.addLevelName(TRACE, "TRACE")
 
 
 class LiveAwareHandler(logging.Handler):
@@ -77,23 +94,33 @@ def get_live_handler() -> LiveAwareHandler | None:
     return _live_handler
 
 
-def setup_logging(*, verbose: bool = False, quiet: bool = False) -> None:
+def setup_logging(*, verbose: bool = False, quiet: bool = False, trace: bool = False) -> None:
     """Configure Python logging for agent-fox.
 
     Sets the root ``agent_fox`` logger level and format.
 
+    Verbosity tiers (highest to lowest detail):
+      - ``trace=True``   → TRACE (5)  — bulk AI payload dumps
+      - ``verbose=True`` → DEBUG (10) — detailed debug messages
+      - default          → WARNING    — normal operation
+      - ``quiet=True``   → ERROR      — errors only
+
     Args:
         verbose: If True, set level to DEBUG (most information).
         quiet: If True, set level to ERROR (errors only).
+        trace: If True, set level to TRACE (enables AI payload dumps).
+               Implies ``verbose``.
 
     Note:
-        When both ``verbose`` and ``quiet`` are True, ``verbose`` wins
-        (01-REQ-6.E1: most information wins).
+        When conflicting flags are set, the most-verbose wins
+        (01-REQ-6.E1: most information wins).  Order: trace > verbose > quiet.
     """
     global _live_handler  # noqa: PLW0603
 
-    # 01-REQ-6.E1: verbose wins when both flags are set
-    if verbose:
+    # 01-REQ-6.E1: most-verbose wins when multiple flags are set
+    if trace:
+        level = TRACE
+    elif verbose:
         level = logging.DEBUG
     elif quiet:
         level = logging.ERROR

--- a/agent_fox/nightshift/critic.py
+++ b/agent_fox/nightshift/critic.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from agent_fox.core.json_extraction import extract_json_object
+from agent_fox.core.logging import TRACE
 from agent_fox.nightshift.finding import Finding, FindingGroup
 
 if TYPE_CHECKING:
@@ -163,8 +164,8 @@ async def _run_critic(
 
     user_message = _build_critic_user_message(findings)
 
-    logger.debug("Critic system prompt:\n%s", _CRITIC_SYSTEM_PROMPT)
-    logger.debug("Critic user message:\n%s", user_message)
+    logger.log(TRACE, "Critic system prompt:\n%s", _CRITIC_SYSTEM_PROMPT)
+    logger.log(TRACE, "Critic user message:\n%s", user_message)
 
     response_text, _response = await nightshift_ai_call(
         model_tier="ADVANCED",
@@ -181,7 +182,7 @@ async def _run_critic(
     if response_text is None:
         raise ValueError("AI critic response has no text content")
 
-    logger.debug("Critic raw response:\n%s", response_text)
+    logger.log(TRACE, "Critic raw response:\n%s", response_text)
     return response_text
 
 

--- a/tests/unit/cli/test_app.py
+++ b/tests/unit/cli/test_app.py
@@ -125,6 +125,58 @@ class TestVersionFlagSkipsBanner:
         assert "/\\_/\\" not in result.output, f"Fox art should not appear with --version, got:\n{result.output!r}"
 
 
+class TestTraceFlagWiring:
+    """--trace flag wires through to setup_logging() and ctx.obj (issue #410)."""
+
+    def test_trace_flag_accepted(self, cli_runner: CliRunner) -> None:
+        """--trace is a valid CLI flag and exits with code 0."""
+        result = cli_runner.invoke(main, ["--trace", "--quiet"])
+        assert result.exit_code == 0, f"--trace should be accepted, got: {result.output!r}"
+
+    def test_trace_calls_setup_logging_with_trace_true(self, cli_runner: CliRunner) -> None:
+        """--trace passes trace=True to setup_logging()."""
+        with patch("agent_fox.cli.app.setup_logging") as mock_setup:
+            cli_runner.invoke(main, ["--trace", "--quiet"])
+
+        mock_setup.assert_called_once()
+        call_kwargs = mock_setup.call_args.kwargs
+        assert call_kwargs.get("trace") is True, (
+            f"Expected trace=True in setup_logging call, got: {call_kwargs}"
+        )
+
+    def test_no_trace_calls_setup_logging_with_trace_false(self, cli_runner: CliRunner) -> None:
+        """Without --trace, setup_logging() receives trace=False."""
+        with patch("agent_fox.cli.app.setup_logging") as mock_setup:
+            cli_runner.invoke(main, ["--quiet"])
+
+        mock_setup.assert_called_once()
+        call_kwargs = mock_setup.call_args.kwargs
+        assert call_kwargs.get("trace") is False, (
+            f"Expected trace=False in setup_logging call, got: {call_kwargs}"
+        )
+
+    def test_trace_stored_in_ctx_obj(self, cli_runner: CliRunner) -> None:
+        """--trace is stored as ctx.obj['trace'] = True for subcommands."""
+        captured: dict = {}
+
+        import click
+
+        @click.command("probe")
+        @click.pass_context
+        def probe(ctx: click.Context) -> None:
+            captured.update(ctx.obj)
+
+        main.add_command(probe, name="probe")
+        try:
+            cli_runner.invoke(main, ["--trace", "probe"])
+        finally:
+            main.commands.pop("probe", None)
+
+        assert captured.get("trace") is True, (
+            f"Expected ctx.obj['trace']=True, got: {captured}"
+        )
+
+
 class TestConfigAutoDiscovery:
     """01-REQ-2.1: CLI auto-discovers .agent-fox/config.toml.
 

--- a/tests/unit/core/test_logging.py
+++ b/tests/unit/core/test_logging.py
@@ -1,0 +1,134 @@
+"""Unit tests for agent-fox logging configuration.
+
+Covers the TRACE custom level and setup_logging() verbosity tiers.
+
+Requirements: 01-REQ-6.1, 01-REQ-6.2, 01-REQ-6.3, 01-REQ-6.E1
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# TRACE level constant
+# ---------------------------------------------------------------------------
+
+
+class TestTraceLevelConstant:
+    """TRACE is defined at level 5 (below DEBUG=10)."""
+
+    def test_trace_value_is_5(self) -> None:
+        """TRACE must equal 5."""
+        from agent_fox.core.logging import TRACE
+
+        assert TRACE == 5
+
+    def test_trace_below_debug(self) -> None:
+        """TRACE must be strictly below logging.DEBUG."""
+        from agent_fox.core.logging import TRACE
+
+        assert TRACE < logging.DEBUG
+
+    def test_trace_level_name_registered(self) -> None:
+        """logging.getLevelName(TRACE) must return 'TRACE'."""
+        from agent_fox.core.logging import TRACE
+
+        assert logging.getLevelName(TRACE) == "TRACE"
+
+
+# ---------------------------------------------------------------------------
+# setup_logging() verbosity tiers
+# ---------------------------------------------------------------------------
+
+
+class TestSetupLoggingTiers:
+    """setup_logging() sets the correct level for each verbosity tier."""
+
+    def _get_agent_fox_level(self) -> int:
+        return logging.getLogger("agent_fox").level
+
+    def test_default_level_is_warning(self) -> None:
+        """No flags → WARNING level."""
+        from agent_fox.core.logging import setup_logging
+
+        setup_logging(verbose=False, quiet=False, trace=False)
+        assert self._get_agent_fox_level() == logging.WARNING
+
+    def test_verbose_sets_debug(self) -> None:
+        """--verbose → DEBUG level."""
+        from agent_fox.core.logging import setup_logging
+
+        setup_logging(verbose=True, quiet=False, trace=False)
+        assert self._get_agent_fox_level() == logging.DEBUG
+
+    def test_quiet_sets_error(self) -> None:
+        """--quiet → ERROR level."""
+        from agent_fox.core.logging import setup_logging
+
+        setup_logging(verbose=False, quiet=True, trace=False)
+        assert self._get_agent_fox_level() == logging.ERROR
+
+    def test_trace_sets_trace_level(self) -> None:
+        """--trace → TRACE level (5)."""
+        from agent_fox.core.logging import TRACE, setup_logging
+
+        setup_logging(verbose=False, quiet=False, trace=True)
+        assert self._get_agent_fox_level() == TRACE
+
+    def test_trace_wins_over_verbose(self) -> None:
+        """--trace --verbose → TRACE level (most verbose wins)."""
+        from agent_fox.core.logging import TRACE, setup_logging
+
+        setup_logging(verbose=True, quiet=False, trace=True)
+        assert self._get_agent_fox_level() == TRACE
+
+    def test_trace_wins_over_quiet(self) -> None:
+        """--trace --quiet → TRACE level (01-REQ-6.E1: most info wins)."""
+        from agent_fox.core.logging import TRACE, setup_logging
+
+        setup_logging(verbose=False, quiet=True, trace=True)
+        assert self._get_agent_fox_level() == TRACE
+
+    def test_verbose_wins_over_quiet(self) -> None:
+        """--verbose --quiet → DEBUG level (01-REQ-6.E1: most info wins)."""
+        from agent_fox.core.logging import setup_logging
+
+        setup_logging(verbose=True, quiet=True, trace=False)
+        assert self._get_agent_fox_level() == logging.DEBUG
+
+
+# ---------------------------------------------------------------------------
+# TRACE emission gating
+# ---------------------------------------------------------------------------
+
+
+class TestTraceLevelEmission:
+    """TRACE records are only emitted when the logger level is TRACE."""
+
+    def test_trace_not_emitted_at_debug_level(self, caplog: pytest.LogCaptureFixture) -> None:
+        """At DEBUG level, TRACE records must not be captured."""
+        from agent_fox.core.logging import TRACE, setup_logging
+
+        setup_logging(verbose=True, quiet=False, trace=False)
+
+        with caplog.at_level(logging.DEBUG, logger="agent_fox"):
+            logging.getLogger("agent_fox.test_sentinel").log(TRACE, "bulk payload dump")
+
+        trace_records = [r for r in caplog.records if r.levelno == TRACE]
+        assert trace_records == [], "TRACE records must not be emitted at DEBUG level"
+
+    def test_trace_emitted_at_trace_level(self, caplog: pytest.LogCaptureFixture) -> None:
+        """At TRACE level, TRACE records must be captured."""
+        from agent_fox.core.logging import TRACE, setup_logging
+
+        setup_logging(verbose=False, quiet=False, trace=True)
+
+        with caplog.at_level(TRACE, logger="agent_fox"):
+            logging.getLogger("agent_fox.test_sentinel").log(TRACE, "bulk payload dump")
+
+        trace_records = [r for r in caplog.records if r.levelno == TRACE]
+        assert len(trace_records) == 1
+        assert "bulk payload dump" in trace_records[0].message

--- a/tests/unit/nightshift/test_critic.py
+++ b/tests/unit/nightshift/test_critic.py
@@ -3,6 +3,9 @@
 Test Spec: TS-73-2, TS-73-5, TS-73-7, TS-73-8, TS-73-10, TS-73-11, TS-73-E6, TS-73-E8
 Requirements: 73-REQ-1.2, 73-REQ-2.3, 73-REQ-3.2, 73-REQ-4.1, 73-REQ-4.2, 73-REQ-4.E1,
               73-REQ-5.E2, 73-REQ-6.3, 73-REQ-7.1, 73-REQ-7.2, 73-REQ-7.3
+
+Trace logging tests verify that bulk AI payloads are only emitted at TRACE level,
+not at DEBUG, so that --verbose remains usable (issue #410).
 """
 
 from __future__ import annotations
@@ -363,3 +366,64 @@ class TestSummaryLog:
         assert "5" in info_messages  # total_received
         assert "1" in info_messages  # total_dropped
         assert "2" in info_messages  # groups_produced
+
+
+# ---------------------------------------------------------------------------
+# Issue #410: Bulk AI payloads must be logged at TRACE, not DEBUG
+# ---------------------------------------------------------------------------
+
+
+class TestBulkPayloadsAtTraceLevel:
+    """Critic's AI prompt/response dumps use TRACE level, not DEBUG (issue #410).
+
+    This ensures --verbose does not emit multi-KB blobs while --trace does.
+    """
+
+    @pytest.mark.asyncio
+    async def test_bulk_payloads_not_emitted_at_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        """System prompt and user message are NOT emitted when level is DEBUG."""
+        from unittest.mock import AsyncMock, patch
+
+        from agent_fox.core.logging import TRACE
+        from agent_fox.nightshift.critic import _run_critic
+
+        findings = [_make_finding(title=f"F{i}") for i in range(3)]
+
+        mock_response = ("raw AI text", object())
+        with patch(
+            "agent_fox.nightshift.cost_helpers.nightshift_ai_call",
+            new=AsyncMock(return_value=mock_response),
+        ), caplog.at_level(logging.DEBUG, logger="agent_fox"):
+            await _run_critic(findings)
+
+        trace_records = [r for r in caplog.records if r.levelno == TRACE]
+        assert trace_records == [], (
+            "TRACE records must not be emitted when the logger level is DEBUG. "
+            f"Got: {[r.message[:80] for r in trace_records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_bulk_payloads_emitted_at_trace(self, caplog: pytest.LogCaptureFixture) -> None:
+        """System prompt, user message, and raw response ARE emitted at TRACE level."""
+        from unittest.mock import AsyncMock, patch
+
+        from agent_fox.core.logging import TRACE
+        from agent_fox.nightshift.critic import _run_critic
+
+        findings = [_make_finding(title=f"F{i}") for i in range(3)]
+
+        mock_response = ("raw AI text for trace check", object())
+        with patch(
+            "agent_fox.nightshift.cost_helpers.nightshift_ai_call",
+            new=AsyncMock(return_value=mock_response),
+        ), caplog.at_level(TRACE, logger="agent_fox"):
+            await _run_critic(findings)
+
+        trace_records = [r for r in caplog.records if r.levelno == TRACE]
+        messages = " ".join(r.message for r in trace_records)
+
+        # All three payload dumps must appear
+        assert "system prompt" in messages.lower(), "Expected critic system prompt log at TRACE"
+        assert "user message" in messages.lower(), "Expected critic user message log at TRACE"
+        assert "raw AI text for trace check" in messages, "Expected raw response log at TRACE"
+        assert len(trace_records) == 3, f"Expected exactly 3 TRACE records, got {len(trace_records)}"


### PR DESCRIPTION
## Summary

Adds a `--trace` CLI flag that gates multi-KB AI prompt/response payload
dumps behind a new `TRACE` log level (value 5, below `DEBUG=10`). With
this change `--verbose` remains usable during night-shift runs, while
`--trace` unlocks the full AI payload dumps for deep debugging.

Closes #410

## Changes

| File | Change |
|------|--------|
| `agent_fox/core/logging.py` | Add `TRACE=5` constant, register level name, update `setup_logging()` to accept `trace=` kwarg |
| `agent_fox/cli/app.py` | Add `--trace` flag; pass `trace=` to `setup_logging()`; store in `ctx.obj` |
| `agent_fox/nightshift/critic.py` | Demote 3 `logger.debug()` calls (system prompt, user message, raw response) to `logger.log(TRACE, ...)` |
| `tests/unit/core/test_logging.py` | New — TRACE constant value, level-name registration, tier ordering, emission gating |
| `tests/unit/cli/test_app.py` | `--trace` flag accepted, wires to `setup_logging(trace=True)`, stored in `ctx.obj` |
| `tests/unit/nightshift/test_critic.py` | Payloads not emitted at DEBUG; all three dumps emitted at TRACE |

## Tests

- `tests/unit/core/test_logging.py`: 8 new tests covering TRACE constant and setup_logging() tier ordering
- `tests/unit/cli/test_app.py`: 4 new tests for `--trace` CLI wiring
- `tests/unit/nightshift/test_critic.py`: 2 new async tests for payload gating

## Verification

- All existing tests pass: ✅
- New tests pass: ✅ (18 new, 4683 total)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*