### PR TITLE
feat(prompt): replace CLAUDE.md with agent_base profile in Layer 1 (fixes #430)

### DIFF
--- a/agent_fox/_templates/profiles/agent_base.md
+++ b/agent_fox/_templates/profiles/agent_base.md
@@ -1,0 +1,58 @@
+## Project Context
+
+You are an agent-fox session agent. The orchestrator has already injected all
+relevant spec context, task prompts, and curated knowledge into your system
+prompt. Work within the context provided.
+
+**Do NOT read `docs/memory.md`.** Relevant knowledge has already been retrieved
+and injected by the adaptive retrieval pipeline. Reading the file directly
+wastes context window on unfiltered, task-irrelevant content.
+
+## Project Structure
+
+```
+agent_fox/              # Main package
+tests/                  # Tests (unit, property, integration)
+docs/                   # Documentation
+.specs/                 # Specifications
+.specs/archive/         # Archived specs (reference only)
+```
+
+## Spec-Driven Workflow
+
+Specifications live in `.specs/NN_name/` and contain:
+
+- `prd.md` -- product requirements document (source of truth)
+- `requirements.md` -- EARS-syntax acceptance criteria
+- `design.md` -- architecture, interfaces, correctness properties
+- `test_spec.md` -- language-agnostic test contracts
+- `tasks.md` -- implementation plan with checkboxes
+
+## Quality Commands
+
+| Command | What it does |
+|---------|-------------|
+| `make check` | Run lint + all tests (use before committing) |
+| `make test` | Run all tests (`uv run pytest -q`) |
+
+## Git Workflow
+
+- Use conventional commits: `<type>: <description>`.
+- Do not switch branches, rebase, or merge into develop -- the orchestrator
+  handles integration.
+- Never push to remote. The orchestrator handles remote integration.
+- Never add `Co-Authored-By` lines. No AI attribution in commits.
+
+## Scope Discipline
+
+- Focus on one coherent change per session.
+- Do not include unrelated "while here" fixes.
+- Fix broken behavior before adding new behavior.
+
+## Documentation
+
+- **ADRs** live in `docs/adr/NN-imperative-verb-phrase.md`.
+- **Errata** live in `docs/errata/NN_snake_case_topic.md` -- for spec
+  divergences.
+- When you add or change user-facing behavior, public APIs, configuration, or
+  architecture, update the relevant documentation in the same session.

--- a/agent_fox/session/prompt.py
+++ b/agent_fox/session/prompt.py
@@ -1,6 +1,6 @@
 """Prompt building: system prompt assembly and task prompt construction.
 
-Assembles a 3-layer system prompt from project context (CLAUDE.md),
+Assembles a 3-layer system prompt from agent base profile,
 archetype profile, and task context.
 
 Requirements: 15-REQ-2.2, 15-REQ-5.1 through 15-REQ-5.E1,
@@ -47,8 +47,8 @@ def build_system_prompt(
     """Build the system prompt using 3-layer assembly.
 
     Assembles a prompt from:
-      - Layer 1: Project context from ``CLAUDE.md`` (omitted if missing or
-        *project_dir* is ``None``).
+      - Layer 1: Agent base profile from ``agent_base.md`` (loaded via
+        :func:`load_profile`; omits if not found).
       - Layer 2: Archetype profile loaded via :func:`load_profile`, with
         mode-aware resolution.
       - Layer 3: Task context (the *context* argument).
@@ -62,7 +62,7 @@ def build_system_prompt(
         mode: Optional archetype mode variant for mode-specific profile
             resolution (e.g. ``"fix"`` loads ``coder_fix.md``).
         project_dir: Root of the project directory.  When provided, enables
-            Layer 1 (CLAUDE.md) and project-level profile overrides.
+            project-level profile overrides for both Layer 1 and Layer 2.
 
     Returns:
         Complete system prompt string.
@@ -73,11 +73,10 @@ def build_system_prompt(
 
     layers: list[str] = []
 
-    # Layer 1: project context (CLAUDE.md) — omit if missing (99-REQ-1.E1)
-    if project_dir is not None:
-        claude_md = project_dir / "CLAUDE.md"
-        if claude_md.exists():
-            layers.append(claude_md.read_text(encoding="utf-8"))
+    # Layer 1: agent base profile (replaces CLAUDE.md)
+    base_profile = load_profile("agent_base", project_dir=project_dir)
+    if base_profile:
+        layers.append(base_profile)
 
     # Layer 2: archetype profile — empty string if not found (99-REQ-1.E2)
     profile = load_profile(resolved, project_dir=project_dir, mode=mode)

--- a/tests/integration/session/test_profile_smoke.py
+++ b/tests/integration/session/test_profile_smoke.py
@@ -36,14 +36,13 @@ class TestPromptWithProjectProfile:
         """
         from agent_fox.session.prompt import build_system_prompt
 
-        # Setup: project CLAUDE.md and custom coder profile
-        claude_content = "PROJECT RULES FOR SMOKE TEST"
+        # Setup: project agent_base and custom coder profile
+        base_content = "PROJECT RULES FOR SMOKE TEST"
         profile_content = "CUSTOM CODER IDENTITY FOR SMOKE TEST"
-
-        (tmp_path / "CLAUDE.md").write_text(claude_content, encoding="utf-8")
 
         profiles_dir = tmp_path / ".agent-fox" / "profiles"
         profiles_dir.mkdir(parents=True)
+        (profiles_dir / "agent_base.md").write_text(base_content, encoding="utf-8")
         (profiles_dir / "coder.md").write_text(profile_content, encoding="utf-8")
 
         task_context = "TASK CONTEXT MARKER"
@@ -56,26 +55,26 @@ class TestPromptWithProjectProfile:
         )
 
         # Expected: all three layers present in order
-        assert claude_content in prompt, "Layer 1 (CLAUDE.md) missing from prompt"
+        assert base_content in prompt, "Layer 1 (agent_base) missing from prompt"
         assert profile_content in prompt, "Layer 2 (profile) missing from prompt"
         assert task_context in prompt, "Layer 3 (task context) missing from prompt"
 
-        # Verify order: CLAUDE.md < profile < task context
-        idx_claude = prompt.index(claude_content)
+        # Verify order: agent_base < profile < task context
+        idx_base = prompt.index(base_content)
         idx_profile = prompt.index(profile_content)
         idx_task = prompt.index(task_context)
-        assert idx_claude < idx_profile, "CLAUDE.md must appear before profile"
+        assert idx_base < idx_profile, "agent_base must appear before profile"
         assert idx_profile < idx_task, "Profile must appear before task context"
 
-    def test_missing_claude_md_still_builds(self, tmp_path: Path) -> None:
-        """TS-99-SMOKE-1 edge: Prompt builds successfully with no CLAUDE.md.
+    def test_default_agent_base_always_loads(self, tmp_path: Path) -> None:
+        """TS-99-SMOKE-1 edge: Package-default agent_base loads when no project override.
 
         Requirement: 99-REQ-1.E1
         """
         from agent_fox.session.prompt import build_system_prompt
 
-        # No CLAUDE.md in project dir
-        profile_content = "CODER IDENTITY NO CLAUDE"
+        # No project-level agent_base — package default should load
+        profile_content = "CODER IDENTITY CUSTOM"
         profiles_dir = tmp_path / ".agent-fox" / "profiles"
         profiles_dir.mkdir(parents=True)
         (profiles_dir / "coder.md").write_text(profile_content, encoding="utf-8")
@@ -88,7 +87,8 @@ class TestPromptWithProjectProfile:
 
         assert len(prompt) > 0
         assert profile_content in prompt
-        assert "CLAUDE.md" not in prompt  # file name should not appear literally
+        # Package-default agent_base content should be present
+        assert "agent-fox session agent" in prompt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/property/test_profile_properties.py
+++ b/tests/property/test_profile_properties.py
@@ -18,7 +18,7 @@ BUILTIN_ARCHETYPES = ["coder", "reviewer", "verifier", "maintainer"]
 @given(st.sampled_from(BUILTIN_ARCHETYPES))
 @settings(max_examples=4)
 def test_layer_order(archetype: str) -> None:
-    """TS-99-P1: Project context always precedes profile precedes task context.
+    """TS-99-P1: Agent base always precedes profile precedes task context.
 
     Property: For any archetype, the three prompt layers appear in order.
     Requirement: 99-REQ-1.1
@@ -27,9 +27,9 @@ def test_layer_order(archetype: str) -> None:
 
     tmp_dir = Path(tempfile.mkdtemp())
     try:
-        (tmp_dir / "CLAUDE.md").write_text("PROJECT_CONTEXT_CONTENT")
         profiles_dir = tmp_dir / ".agent-fox" / "profiles"
         profiles_dir.mkdir(parents=True)
+        (profiles_dir / "agent_base.md").write_text("BASE_CONTEXT_CONTENT")
         marker = f"PROFILE_{archetype.upper()}_CONTENT"
         (profiles_dir / f"{archetype}.md").write_text(marker)
 
@@ -39,14 +39,14 @@ def test_layer_order(archetype: str) -> None:
             project_dir=tmp_dir,
         )
 
-        assert "PROJECT_CONTEXT_CONTENT" in prompt
+        assert "BASE_CONTEXT_CONTENT" in prompt
         assert marker in prompt
         assert "TASK_CONTEXT_MARKER" in prompt
 
-        idx_claude = prompt.index("PROJECT_CONTEXT_CONTENT")
+        idx_base = prompt.index("BASE_CONTEXT_CONTENT")
         idx_profile = prompt.index(marker)
         idx_task = prompt.index("TASK_CONTEXT_MARKER")
-        assert idx_claude < idx_profile < idx_task
+        assert idx_base < idx_profile < idx_task
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
 

--- a/tests/unit/session/test_prompt.py
+++ b/tests/unit/session/test_prompt.py
@@ -178,9 +178,11 @@ class TestProfileWithoutFrontmatterUnchanged:
 class TestThreeLayerAssemblyWithProjectDir:
     """Verify 3-layer assembly works correctly with project_dir."""
 
-    def test_project_claude_md_included(self, tmp_path: Path) -> None:
-        """CLAUDE.md content is included as Layer 1."""
-        (tmp_path / "CLAUDE.md").write_text("PROJECT RULES")
+    def test_project_agent_base_included(self, tmp_path: Path) -> None:
+        """agent_base profile content is included as Layer 1."""
+        profiles_dir = tmp_path / ".agent-fox" / "profiles"
+        profiles_dir.mkdir(parents=True)
+        (profiles_dir / "agent_base.md").write_text("PROJECT RULES")
         result = build_system_prompt("ctx", archetype="coder", project_dir=tmp_path)
         assert "PROJECT RULES" in result
 

--- a/tests/unit/session/test_prompt_layers.py
+++ b/tests/unit/session/test_prompt_layers.py
@@ -11,7 +11,7 @@ from pathlib import Path
 def test_3_layer_order(tmp_path: Path) -> None:
     """TS-99-1: Prompt layers appear in correct order.
 
-    Layer 1: project context (CLAUDE.md)
+    Layer 1: agent base profile
     Layer 2: archetype profile
     Layer 3: task context
 
@@ -19,12 +19,13 @@ def test_3_layer_order(tmp_path: Path) -> None:
     """
     from agent_fox.session.prompt import build_system_prompt
 
-    # Layer 1: project context
-    (tmp_path / "CLAUDE.md").write_text("PROJECT_CONTEXT_CONTENT")
-
-    # Layer 2: custom profile
     profiles_dir = tmp_path / ".agent-fox" / "profiles"
     profiles_dir.mkdir(parents=True)
+
+    # Layer 1: agent base profile
+    (profiles_dir / "agent_base.md").write_text("PROJECT_CONTEXT_CONTENT")
+
+    # Layer 2: custom archetype profile
     (profiles_dir / "coder.md").write_text("PROFILE_CONTENT_MARKER")
 
     # Layer 3: task context (passed as context string)
@@ -36,21 +37,23 @@ def test_3_layer_order(tmp_path: Path) -> None:
         project_dir=tmp_path,
     )
 
-    idx_claude = prompt.index("PROJECT_CONTEXT_CONTENT")
+    idx_base = prompt.index("PROJECT_CONTEXT_CONTENT")
     idx_profile = prompt.index("PROFILE_CONTENT_MARKER")
     idx_task = prompt.index("TASK_CONTEXT_MARKER")
 
-    assert idx_claude < idx_profile < idx_task
+    assert idx_base < idx_profile < idx_task
 
 
-def test_missing_claude_md(tmp_path: Path) -> None:
-    """TS-99-E1: Prompt assembly works without CLAUDE.md.
+def test_missing_agent_base(tmp_path: Path) -> None:
+    """TS-99-E1: Prompt assembly works without project-level agent_base.
+
+    The package-default agent_base.md is always available, so Layer 1
+    is populated from the built-in template.
 
     Requirement: 99-REQ-1.E1
     """
     from agent_fox.session.prompt import build_system_prompt
 
-    # No CLAUDE.md in tmp_path — should not raise
     task_context = "TASK_CONTEXT_MARKER"
 
     prompt = build_system_prompt(


### PR DESCRIPTION
## Summary

Replaces raw `CLAUDE.md` reading in Layer 1 of `build_system_prompt()` with a dedicated `agent_base.md` profile loaded via the existing `load_profile()` infrastructure. The new template is minimal (~500 tokens), explicitly forbids reading `docs/memory.md`, and removes all interactive-agent instructions that the orchestrator already handles. `CLAUDE.md` remains unchanged for external agents.

Closes #430

## Changes

| File | Change |
|------|--------|
| `agent_fox/_templates/profiles/agent_base.md` | New minimal agent prompt template for Layer 1 |
| `agent_fox/session/prompt.py` | Layer 1 calls `load_profile("agent_base", ...)` instead of reading `CLAUDE.md` |
| `tests/unit/session/test_prompt.py` | Updated Layer 1 test to use agent_base profile |
| `tests/unit/session/test_prompt_layers.py` | Updated ordering and edge case tests |
| `tests/integration/session/test_profile_smoke.py` | Updated smoke tests for new Layer 1 |
| `tests/property/test_profile_properties.py` | Updated layer order property test |

## Tests

- Unit: Layer 1 inclusion, 3-layer ordering, missing-profile edge case
- Integration: End-to-end smoke with project override and package default
- Property: Layer ordering holds across all built-in archetypes

## Verification

- All existing tests pass: ✅ (4688 passed)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*