### PR TITLE
fix(tests): fix hollow generate_status test and production bug (fixes #428)

### DIFF
--- a/agent_fox/cli/status.py
+++ b/agent_fox/cli/status.py
@@ -23,6 +23,7 @@ from agent_fox.reporting.formatters import (
     get_formatter,
     write_output,
 )
+from agent_fox.reporting.status import StatusReport
 from agent_fox.reporting.status import generate_status as _reporting_generate_status
 
 logger = logging.getLogger(__name__)
@@ -30,19 +31,29 @@ logger = logging.getLogger(__name__)
 
 def generate_status(
     db_path: Path | None = None,
-) -> None:
-    """Graceful existence check for the DuckDB status file (TS-105-E6).
+) -> StatusReport | None:
+    """Generate a status report from a DuckDB database file (TS-105-E6).
 
-    Returns ``None`` when ``db_path`` is absent so ``af status`` can display
-    "No plan found" instead of raising an exception.  The full status report
-    is rendered by ``_reporting_generate_status`` inside ``status_cmd``, which
-    accepts an optional DuckDB connection for plan_nodes queries.
+    Returns ``None`` when ``db_path`` is absent or does not exist, so the
+    caller can display "No plan found" instead of raising an exception.  When
+    the database file is present, opens a read-only connection and delegates
+    to the reporting layer to produce a full ``StatusReport``.
 
     Requirements: 105-REQ-6.E1
     """
     if db_path is None or not Path(db_path).exists():
         return None
-    return None
+    try:
+        import duckdb as _duckdb
+
+        conn = _duckdb.connect(str(db_path), read_only=True)
+        try:
+            return _reporting_generate_status(db_conn=conn)
+        finally:
+            conn.close()
+    except Exception:
+        logger.debug("Failed to generate status from DB at %s", db_path, exc_info=True)
+        return None
 
 
 def _get_readonly_conn():

--- a/tests/unit/engine/test_db_plan_state.py
+++ b/tests/unit/engine/test_db_plan_state.py
@@ -567,17 +567,40 @@ def test_load_state_from_db_empty_plan_nodes_loads_run_totals(
 
 
 def test_missing_db_status(tmp_path) -> None:
-    """TS-105-E6: af status displays 'No plan found' when DB does not exist.
+    """TS-105-E6: generate_status returns None when DB does not exist.
 
     Requirements: 105-REQ-6.E1
     """
     nonexistent_db = tmp_path / "nonexistent.duckdb"
     assert not nonexistent_db.exists()
 
-    # The status command or generate_status function must handle missing DB
-    # gracefully (no crash, shows "No plan found" or empty dashboard).
-    from agent_fox.cli.status import generate_status  # noqa: F401
+    from agent_fox.cli.status import generate_status
 
     result = generate_status(db_path=nonexistent_db)
-    # Either result contains "No plan found" or is a falsy/empty value
-    assert result is None or "No plan found" in str(result) or result == {}
+    # Must be exactly None — not a falsy-but-meaningful value
+    assert result is None
+
+
+def test_existing_db_status(tmp_path) -> None:
+    """TS-105-E6 (existing DB): generate_status returns a StatusReport when DB exists.
+
+    Regression guard: ensures generate_status does not always return None,
+    which would make test_missing_db_status trivially pass and hide the bug.
+
+    Requirements: 105-REQ-6.E1
+    """
+    import duckdb as _duckdb
+
+    from agent_fox.cli.status import generate_status
+    from agent_fox.reporting.status import StatusReport
+
+    db_path = tmp_path / "test_status.duckdb"
+    conn = _duckdb.connect(str(db_path))
+    conn.execute(_FULL_SCHEMA_DDL)
+    conn.close()
+    assert db_path.exists()
+
+    result = generate_status(db_path=db_path)
+    # Must return a StatusReport, not None, when the DB file is present
+    assert result is not None
+    assert isinstance(result, StatusReport)


### PR DESCRIPTION
## Summary

`generate_status` in `agent_fox/cli/status.py` always returned `None` due to a dead `return None` on line 45 — even when the database file existed. This made `test_missing_db_status` trivially pass via a weak disjunctive assertion, hiding the production bug.

Closes #428

## Changes

| File | Change |
|------|--------|
| `agent_fox/cli/status.py` | Fix `generate_status` to open a read-only DuckDB connection and call `_reporting_generate_status` when db_path exists; update return type to `StatusReport \| None` |
| `tests/unit/engine/test_db_plan_state.py` | Replace weak disjunctive assertion in `test_missing_db_status` with strict `assert result is None`; add `test_existing_db_status` regression guard |

## Tests

- `test_missing_db_status`: Strict `assert result is None` when DB is absent
- `test_existing_db_status`: Asserts `generate_status` returns a `StatusReport` (not None) when DB exists — prevents hollow-test regression

## Verification

- All existing tests pass: ✅ (4690 passed, 0 failed)
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*