### PR TITLE
fix(hot-load): skip fully implemented specs during discovery (fixes #444)

### DIFF
--- a/agent_fox/cli/nightshift.py
+++ b/agent_fox/cli/nightshift.py
@@ -206,9 +206,10 @@ def night_shift_cmd(
 
     _known_specs: set[str] = set()
     _specs_dir = project_root / ".specs"
+    _plan_path = project_root / ".agent-fox" / "plan.json"
 
     async def _discover_fn() -> list:
-        found = await discover_new_specs_gated(_specs_dir, _known_specs, project_root)
+        found = await discover_new_specs_gated(_specs_dir, _known_specs, project_root, plan_path=_plan_path)
         for spec in found:
             _known_specs.add(spec.name)
         return found

--- a/agent_fox/engine/engine.py
+++ b/agent_fox/engine/engine.py
@@ -1303,7 +1303,7 @@ class Orchestrator:
         # 51-REQ-4.1, 51-REQ-5.1, 51-REQ-6.1: Gated discovery — single pass
         repo_root = self._plan_path.parent
         known_specs = {n.spec_name for n in self._graph.nodes.values()}
-        gated_specs = await discover_new_specs_gated(self._specs_dir, known_specs, repo_root)
+        gated_specs = await discover_new_specs_gated(self._specs_dir, known_specs, repo_root, plan_path=self._plan_path)
 
         if not gated_specs:
             return

--- a/agent_fox/engine/hot_load.py
+++ b/agent_fox/engine/hot_load.py
@@ -164,21 +164,80 @@ def lint_spec_gate(spec_name: str, spec_path: Path) -> tuple[bool, list[str]]:
         return (False, [f"Validator error: {exc}"])
 
 
+def are_all_tasks_done(spec_path: Path) -> bool:
+    """Check if all task groups in tasks.md are marked complete.
+
+    Returns True only when tasks.md exists, contains at least one group,
+    and every group has ``completed=True``.
+
+    Args:
+        spec_path: Path to the spec folder (e.g., ``.specs/42_feature``).
+
+    Returns:
+        True if all task groups are completed, False otherwise.
+    """
+    tasks_path = spec_path / "tasks.md"
+    if not tasks_path.is_file():
+        return False
+    try:
+        groups = parse_tasks(tasks_path)
+    except Exception:
+        return False
+    if not groups:
+        return False
+    return all(g.completed for g in groups)
+
+
+def _are_all_plan_nodes_done(
+    spec_name: str,
+    graph: TaskGraph | None,
+) -> bool:
+    """Check if all nodes for a spec in the plan graph are completed.
+
+    Returns True only when the graph exists, contains nodes for this
+    spec, and all of them have ``NodeStatus.COMPLETED``.
+
+    Args:
+        spec_name: The spec name to check (e.g., ``"42_feature"``).
+        graph: The loaded plan graph, or None if unavailable.
+
+    Returns:
+        True if all nodes for the spec are completed, False otherwise.
+    """
+    if graph is None:
+        return False
+    spec_nodes = [n for n in graph.nodes.values() if n.spec_name == spec_name]
+    if not spec_nodes:
+        return False
+    return all(n.status == NodeStatus.COMPLETED for n in spec_nodes)
+
+
 async def discover_new_specs_gated(
     specs_dir: Path,
     known_specs: set[str],
     repo_root: Path,
+    *,
+    plan_path: Path | None = None,
 ) -> list[SpecInfo]:
-    """Discover new specs that pass all three gates.
+    """Discover new specs that pass all four gates.
 
     Pipeline:
     1. Filesystem discovery (existing ``discover_new_specs``).
     2. Gate 1: git-tracked on develop.
     3. Gate 2: all 5 required files present and non-empty.
     4. Gate 3: no lint errors from validator.
+    5. Gate 4: not already fully implemented (tasks.md + plan state).
 
     Returns only specs that pass all gates.  Skipped specs are
     re-evaluated at the next barrier with a clean slate (51-REQ-7.2).
+
+    Args:
+        specs_dir: Path to the .specs/ directory.
+        known_specs: Set of spec names already in the current plan.
+        repo_root: Path to the repository root (for git checks).
+        plan_path: Optional path to plan.json for the tasks-complete gate.
+            When None, the plan node check is skipped (gate degrades
+            gracefully — specs are never skipped based on plan state alone).
 
     Requirements: 51-REQ-4.1, 51-REQ-5.1, 51-REQ-6.1, 51-REQ-7.1,
                   51-REQ-7.2, 51-REQ-7.3
@@ -186,6 +245,13 @@ async def discover_new_specs_gated(
     candidates = discover_new_specs(specs_dir, known_specs)
     if not candidates:
         return []
+
+    # Load plan graph once for the tasks-complete gate (Gate 4).
+    plan_graph: TaskGraph | None = None
+    if plan_path is not None:
+        from agent_fox.graph.persistence import load_plan
+
+        plan_graph = load_plan(plan_path)
 
     accepted: list[SpecInfo] = []
     for spec in candidates:
@@ -212,6 +278,15 @@ async def discover_new_specs_gated(
                 "Spec '%s' has lint errors: %s, skipping",
                 spec.name,
                 "; ".join(errors),
+            )
+            continue
+
+        # Gate 4: tasks-complete — skip specs that are fully implemented.
+        # Both tasks.md AND plan node state must agree the spec is done.
+        if are_all_tasks_done(spec.path) and _are_all_plan_nodes_done(spec.name, plan_graph):
+            logger.info(
+                "Spec '%s' is fully implemented (all tasks complete, all plan nodes done), skipping",
+                spec.name,
             )
             continue
 

--- a/tests/unit/engine/test_hot_load_gates.py
+++ b/tests/unit/engine/test_hot_load_gates.py
@@ -1,10 +1,11 @@
-"""Hot-load gate pipeline tests: git-tracked, completeness, lint gates.
+"""Hot-load gate pipeline tests: git-tracked, completeness, lint, tasks-complete gates.
 
-Test Spec: TS-51-12 through TS-51-22
+Test Spec: TS-51-12 through TS-51-22, TS-444-1 through TS-444-5
 Requirements: 51-REQ-4.1, 51-REQ-4.2, 51-REQ-4.E1,
               51-REQ-5.1, 51-REQ-5.2, 51-REQ-5.E1,
               51-REQ-6.1, 51-REQ-6.2, 51-REQ-6.3, 51-REQ-6.E1,
-              51-REQ-7.1, 51-REQ-7.2, 51-REQ-7.3
+              51-REQ-7.1, 51-REQ-7.2, 51-REQ-7.3,
+              444-AC-1, 444-AC-2, 444-AC-3, 444-AC-4
 """
 
 from __future__ import annotations
@@ -16,6 +17,8 @@ from unittest.mock import patch
 import pytest
 
 from agent_fox.engine.hot_load import (
+    _are_all_plan_nodes_done,
+    are_all_tasks_done,
     discover_new_specs_gated,
     is_spec_complete,
     is_spec_tracked_on_develop,
@@ -491,3 +494,480 @@ class TestSkippedSpecReEvaluation:
             result_2 = await discover_new_specs_gated(specs_dir, known_specs=set(), repo_root=tmp_path)
             assert len(result_2) == 1
             assert result_2[0].name == "42_feature"
+
+
+# ---------------------------------------------------------------------------
+# TS-444-1: are_all_tasks_done
+# ---------------------------------------------------------------------------
+
+_COMPLETED_TASKS_MD = """\
+# Tasks
+
+- [x] 1. First task group
+  - [x] 1.1 Subtask one
+  - [x] 1.2 Subtask two
+- [x] 2. Second task group
+  - [x] 2.1 Subtask one
+"""
+
+_INCOMPLETE_TASKS_MD = """\
+# Tasks
+
+- [x] 1. First task group
+  - [x] 1.1 Subtask one
+- [ ] 2. Second task group
+  - [ ] 2.1 Subtask one
+"""
+
+_ALL_INCOMPLETE_TASKS_MD = """\
+# Tasks
+
+- [ ] 1. First task group
+  - [ ] 1.1 Subtask one
+- [ ] 2. Second task group
+  - [ ] 2.1 Subtask one
+"""
+
+
+class TestAreAllTasksDone:
+    """TS-444-1: tasks.md checkbox gate for completed specs.
+
+    Requirements: 444-AC-1
+    """
+
+    def test_all_groups_completed(self, tmp_path: Path) -> None:
+        """Returns True when all task groups are marked [x]."""
+        spec_path = tmp_path / "42_feature"
+        spec_path.mkdir()
+        (spec_path / "tasks.md").write_text(_COMPLETED_TASKS_MD)
+
+        assert are_all_tasks_done(spec_path) is True
+
+    def test_some_groups_incomplete(self, tmp_path: Path) -> None:
+        """Returns False when some groups are not completed."""
+        spec_path = tmp_path / "42_feature"
+        spec_path.mkdir()
+        (spec_path / "tasks.md").write_text(_INCOMPLETE_TASKS_MD)
+
+        assert are_all_tasks_done(spec_path) is False
+
+    def test_no_groups_found(self, tmp_path: Path) -> None:
+        """Returns False when tasks.md has no parseable groups."""
+        spec_path = tmp_path / "42_feature"
+        spec_path.mkdir()
+        (spec_path / "tasks.md").write_text("# Tasks\n\nNo task groups here.\n")
+
+        assert are_all_tasks_done(spec_path) is False
+
+    def test_tasks_md_missing(self, tmp_path: Path) -> None:
+        """Returns False when tasks.md does not exist."""
+        spec_path = tmp_path / "42_feature"
+        spec_path.mkdir()
+
+        assert are_all_tasks_done(spec_path) is False
+
+    def test_parse_error(self, tmp_path: Path) -> None:
+        """Returns False when parse_tasks raises an exception."""
+        spec_path = tmp_path / "42_feature"
+        spec_path.mkdir()
+        (spec_path / "tasks.md").write_text(_COMPLETED_TASKS_MD)
+
+        with patch(
+            "agent_fox.engine.hot_load.parse_tasks",
+            side_effect=RuntimeError("parse error"),
+        ):
+            assert are_all_tasks_done(spec_path) is False
+
+    def test_new_unchecked_tasks_added(self, tmp_path: Path) -> None:
+        """Returns False when previously complete spec has new unchecked tasks.
+
+        Acceptance criterion: 444-AC-4
+        """
+        tasks_with_new = """\
+# Tasks
+
+- [x] 1. First task group
+  - [x] 1.1 Subtask one
+- [x] 2. Second task group
+  - [x] 2.1 Subtask one
+- [ ] 3. New task group added later
+  - [ ] 3.1 New subtask
+"""
+        spec_path = tmp_path / "42_feature"
+        spec_path.mkdir()
+        (spec_path / "tasks.md").write_text(tasks_with_new)
+
+        assert are_all_tasks_done(spec_path) is False
+
+
+# ---------------------------------------------------------------------------
+# TS-444-2: _are_all_plan_nodes_done
+# ---------------------------------------------------------------------------
+
+
+class TestAreAllPlanNodesDone:
+    """TS-444-2: plan node state gate for completed specs.
+
+    Requirements: 444-AC-2
+    """
+
+    def test_all_nodes_completed(self) -> None:
+        """Returns True when all nodes for spec have COMPLETED status."""
+        from agent_fox.graph.types import Node, NodeStatus, TaskGraph
+
+        graph = TaskGraph(
+            nodes={
+                "42_feature:0": Node(
+                    id="42_feature:0",
+                    spec_name="42_feature",
+                    group_number=0,
+                    title="Group 0",
+                    optional=False,
+                    status=NodeStatus.COMPLETED,
+                ),
+                "42_feature:1": Node(
+                    id="42_feature:1",
+                    spec_name="42_feature",
+                    group_number=1,
+                    title="Group 1",
+                    optional=False,
+                    status=NodeStatus.COMPLETED,
+                ),
+            },
+            edges=[],
+            order=["42_feature:0", "42_feature:1"],
+        )
+
+        assert _are_all_plan_nodes_done("42_feature", graph) is True
+
+    def test_some_nodes_not_completed(self) -> None:
+        """Returns False when some nodes are pending."""
+        from agent_fox.graph.types import Node, NodeStatus, TaskGraph
+
+        graph = TaskGraph(
+            nodes={
+                "42_feature:0": Node(
+                    id="42_feature:0",
+                    spec_name="42_feature",
+                    group_number=0,
+                    title="Group 0",
+                    optional=False,
+                    status=NodeStatus.COMPLETED,
+                ),
+                "42_feature:1": Node(
+                    id="42_feature:1",
+                    spec_name="42_feature",
+                    group_number=1,
+                    title="Group 1",
+                    optional=False,
+                    status=NodeStatus.PENDING,
+                ),
+            },
+            edges=[],
+            order=["42_feature:0", "42_feature:1"],
+        )
+
+        assert _are_all_plan_nodes_done("42_feature", graph) is False
+
+    def test_no_nodes_for_spec(self) -> None:
+        """Returns False when plan has no nodes for this spec."""
+        from agent_fox.graph.types import Node, NodeStatus, TaskGraph
+
+        graph = TaskGraph(
+            nodes={
+                "99_other:0": Node(
+                    id="99_other:0",
+                    spec_name="99_other",
+                    group_number=0,
+                    title="Other",
+                    optional=False,
+                    status=NodeStatus.COMPLETED,
+                ),
+            },
+            edges=[],
+            order=["99_other:0"],
+        )
+
+        assert _are_all_plan_nodes_done("42_feature", graph) is False
+
+    def test_graph_is_none(self) -> None:
+        """Returns False when no plan graph is available."""
+        assert _are_all_plan_nodes_done("42_feature", None) is False
+
+
+# ---------------------------------------------------------------------------
+# TS-444-3: Gate 4 integration in discover_new_specs_gated pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestTasksCompleteGatePipeline:
+    """TS-444-3: Tasks-complete gate filters fully implemented specs.
+
+    Requirements: 444-AC-1, 444-AC-2, 444-AC-3, 444-AC-4
+    """
+
+    @pytest.mark.asyncio
+    async def test_both_signals_done_skips_spec(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """Spec skipped when tasks.md all [x] AND plan nodes all completed."""
+        from agent_fox.spec.discovery import SpecInfo
+
+        specs_dir = tmp_path / ".specs"
+        spec_path = specs_dir / "42_feature"
+        _create_spec_files(spec_path)
+        # Overwrite tasks.md with completed content (after _create_spec_files)
+        (spec_path / "tasks.md").write_text(_COMPLETED_TASKS_MD)
+
+        # Create plan.json with completed nodes
+        from agent_fox.graph.types import Node, NodeStatus, TaskGraph
+
+        plan_graph = TaskGraph(
+            nodes={
+                "42_feature:1": Node(
+                    id="42_feature:1",
+                    spec_name="42_feature",
+                    group_number=1,
+                    title="First",
+                    optional=False,
+                    status=NodeStatus.COMPLETED,
+                ),
+                "42_feature:2": Node(
+                    id="42_feature:2",
+                    spec_name="42_feature",
+                    group_number=2,
+                    title="Second",
+                    optional=False,
+                    status=NodeStatus.COMPLETED,
+                ),
+            },
+            edges=[],
+            order=["42_feature:1", "42_feature:2"],
+        )
+
+        from agent_fox.graph.persistence import save_plan
+
+        plan_path = tmp_path / ".agent-fox" / "plan.json"
+        plan_path.parent.mkdir(parents=True, exist_ok=True)
+        save_plan(plan_graph, plan_path)
+
+        mock_spec = SpecInfo(
+            name="42_feature",
+            prefix=42,
+            path=spec_path,
+            has_tasks=True,
+            has_prd=True,
+        )
+
+        async def mock_is_tracked(repo_root: Path, spec_name: str, **kwargs: object) -> bool:
+            return True
+
+        def mock_lint_gate(spec_name: str, spec_path: Path) -> tuple[bool, list[str]]:
+            return (True, [])
+
+        with (
+            patch("agent_fox.engine.hot_load.discover_new_specs", return_value=[mock_spec]),
+            patch("agent_fox.engine.hot_load.is_spec_tracked_on_develop", side_effect=mock_is_tracked),
+            patch("agent_fox.engine.hot_load.is_spec_complete", return_value=(True, [])),
+            patch("agent_fox.engine.hot_load.lint_spec_gate", side_effect=mock_lint_gate),
+            caplog.at_level(logging.INFO, logger="agent_fox.engine.hot_load"),
+        ):
+            result = await discover_new_specs_gated(
+                specs_dir, known_specs=set(), repo_root=tmp_path, plan_path=plan_path
+            )
+
+        assert result == []
+        assert any("fully implemented" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_tasks_done_but_nodes_not_done(self, tmp_path: Path) -> None:
+        """Spec NOT skipped when tasks.md all [x] but plan nodes are pending."""
+        from agent_fox.spec.discovery import SpecInfo
+
+        specs_dir = tmp_path / ".specs"
+        spec_path = specs_dir / "42_feature"
+        _create_spec_files(spec_path)
+        (spec_path / "tasks.md").write_text(_COMPLETED_TASKS_MD)
+
+        # Create plan.json with pending nodes
+        from agent_fox.graph.types import Node, NodeStatus, TaskGraph
+
+        plan_graph = TaskGraph(
+            nodes={
+                "42_feature:1": Node(
+                    id="42_feature:1",
+                    spec_name="42_feature",
+                    group_number=1,
+                    title="First",
+                    optional=False,
+                    status=NodeStatus.PENDING,
+                ),
+            },
+            edges=[],
+            order=["42_feature:1"],
+        )
+
+        from agent_fox.graph.persistence import save_plan
+
+        plan_path = tmp_path / ".agent-fox" / "plan.json"
+        plan_path.parent.mkdir(parents=True, exist_ok=True)
+        save_plan(plan_graph, plan_path)
+
+        mock_spec = SpecInfo(
+            name="42_feature",
+            prefix=42,
+            path=spec_path,
+            has_tasks=True,
+            has_prd=True,
+        )
+
+        async def mock_is_tracked(repo_root: Path, spec_name: str, **kwargs: object) -> bool:
+            return True
+
+        def mock_lint_gate(spec_name: str, spec_path: Path) -> tuple[bool, list[str]]:
+            return (True, [])
+
+        with (
+            patch("agent_fox.engine.hot_load.discover_new_specs", return_value=[mock_spec]),
+            patch("agent_fox.engine.hot_load.is_spec_tracked_on_develop", side_effect=mock_is_tracked),
+            patch("agent_fox.engine.hot_load.is_spec_complete", return_value=(True, [])),
+            patch("agent_fox.engine.hot_load.lint_spec_gate", side_effect=mock_lint_gate),
+        ):
+            result = await discover_new_specs_gated(
+                specs_dir, known_specs=set(), repo_root=tmp_path, plan_path=plan_path
+            )
+
+        assert len(result) == 1
+        assert result[0].name == "42_feature"
+
+    @pytest.mark.asyncio
+    async def test_nodes_done_but_tasks_not_done(self, tmp_path: Path) -> None:
+        """Spec NOT skipped when plan nodes completed but tasks.md has unchecked boxes."""
+        from agent_fox.spec.discovery import SpecInfo
+
+        specs_dir = tmp_path / ".specs"
+        spec_path = specs_dir / "42_feature"
+        _create_spec_files(spec_path)
+        (spec_path / "tasks.md").write_text(_INCOMPLETE_TASKS_MD)
+
+        from agent_fox.graph.types import Node, NodeStatus, TaskGraph
+
+        plan_graph = TaskGraph(
+            nodes={
+                "42_feature:1": Node(
+                    id="42_feature:1",
+                    spec_name="42_feature",
+                    group_number=1,
+                    title="First",
+                    optional=False,
+                    status=NodeStatus.COMPLETED,
+                ),
+            },
+            edges=[],
+            order=["42_feature:1"],
+        )
+
+        from agent_fox.graph.persistence import save_plan
+
+        plan_path = tmp_path / ".agent-fox" / "plan.json"
+        plan_path.parent.mkdir(parents=True, exist_ok=True)
+        save_plan(plan_graph, plan_path)
+
+        mock_spec = SpecInfo(
+            name="42_feature",
+            prefix=42,
+            path=spec_path,
+            has_tasks=True,
+            has_prd=True,
+        )
+
+        async def mock_is_tracked(repo_root: Path, spec_name: str, **kwargs: object) -> bool:
+            return True
+
+        def mock_lint_gate(spec_name: str, spec_path: Path) -> tuple[bool, list[str]]:
+            return (True, [])
+
+        with (
+            patch("agent_fox.engine.hot_load.discover_new_specs", return_value=[mock_spec]),
+            patch("agent_fox.engine.hot_load.is_spec_tracked_on_develop", side_effect=mock_is_tracked),
+            patch("agent_fox.engine.hot_load.is_spec_complete", return_value=(True, [])),
+            patch("agent_fox.engine.hot_load.lint_spec_gate", side_effect=mock_lint_gate),
+        ):
+            result = await discover_new_specs_gated(
+                specs_dir, known_specs=set(), repo_root=tmp_path, plan_path=plan_path
+            )
+
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_plan_file_does_not_skip(self, tmp_path: Path) -> None:
+        """Spec NOT skipped when plan.json does not exist (even if tasks all done)."""
+        from agent_fox.spec.discovery import SpecInfo
+
+        specs_dir = tmp_path / ".specs"
+        spec_path = specs_dir / "42_feature"
+        _create_spec_files(spec_path)
+        (spec_path / "tasks.md").write_text(_COMPLETED_TASKS_MD)
+
+        plan_path = tmp_path / ".agent-fox" / "plan.json"  # does not exist
+
+        mock_spec = SpecInfo(
+            name="42_feature",
+            prefix=42,
+            path=spec_path,
+            has_tasks=True,
+            has_prd=True,
+        )
+
+        async def mock_is_tracked(repo_root: Path, spec_name: str, **kwargs: object) -> bool:
+            return True
+
+        def mock_lint_gate(spec_name: str, spec_path: Path) -> tuple[bool, list[str]]:
+            return (True, [])
+
+        with (
+            patch("agent_fox.engine.hot_load.discover_new_specs", return_value=[mock_spec]),
+            patch("agent_fox.engine.hot_load.is_spec_tracked_on_develop", side_effect=mock_is_tracked),
+            patch("agent_fox.engine.hot_load.is_spec_complete", return_value=(True, [])),
+            patch("agent_fox.engine.hot_load.lint_spec_gate", side_effect=mock_lint_gate),
+        ):
+            result = await discover_new_specs_gated(
+                specs_dir, known_specs=set(), repo_root=tmp_path, plan_path=plan_path
+            )
+
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_plan_path_provided(self, tmp_path: Path) -> None:
+        """Spec NOT skipped when plan_path is None (backward compat)."""
+        from agent_fox.spec.discovery import SpecInfo
+
+        specs_dir = tmp_path / ".specs"
+        spec_path = specs_dir / "42_feature"
+        _create_spec_files(spec_path)
+        (spec_path / "tasks.md").write_text(_COMPLETED_TASKS_MD)
+
+        mock_spec = SpecInfo(
+            name="42_feature",
+            prefix=42,
+            path=spec_path,
+            has_tasks=True,
+            has_prd=True,
+        )
+
+        async def mock_is_tracked(repo_root: Path, spec_name: str, **kwargs: object) -> bool:
+            return True
+
+        def mock_lint_gate(spec_name: str, spec_path: Path) -> tuple[bool, list[str]]:
+            return (True, [])
+
+        with (
+            patch("agent_fox.engine.hot_load.discover_new_specs", return_value=[mock_spec]),
+            patch("agent_fox.engine.hot_load.is_spec_tracked_on_develop", side_effect=mock_is_tracked),
+            patch("agent_fox.engine.hot_load.is_spec_complete", return_value=(True, [])),
+            patch("agent_fox.engine.hot_load.lint_spec_gate", side_effect=mock_lint_gate),
+        ):
+            # No plan_path argument — backward compatible
+            result = await discover_new_specs_gated(
+                specs_dir, known_specs=set(), repo_root=tmp_path
+            )
+
+        assert len(result) == 1


### PR DESCRIPTION
## Summary

- Added a tasks-complete gate (Gate 4) to `discover_new_specs_gated()` that checks both tasks.md checkbox state and plan.json node state before accepting a spec
- Specs where all task groups are `[x]` AND all plan nodes are `completed` are skipped during discovery, preventing wasteful re-processing on daemon restart
- Gate degrades gracefully when `plan_path` is not provided (backward compatible)

Closes #444

## Changes

| File | Change |
|------|--------|
| `agent_fox/engine/hot_load.py` | Added `are_all_tasks_done()`, `_are_all_plan_nodes_done()`, and Gate 4 in `discover_new_specs_gated()` |
| `agent_fox/engine/engine.py` | Pass `plan_path` to gated discovery in sync barrier |
| `agent_fox/cli/nightshift.py` | Pass `plan_path` to gated discovery in nightshift closure |
| `tests/unit/engine/test_hot_load_gates.py` | Added 15 new tests for gate functions and pipeline integration |

## Tests

- `TestAreAllTasksDone`: 6 tests (all-done, partial, empty, missing, parse error, new tasks added)
- `TestAreAllPlanNodesDone`: 4 tests (all-done, partial, no nodes, no graph)
- `TestTasksCompleteGatePipeline`: 5 tests (both signals done, tasks-only, nodes-only, no plan file, no plan path)

## Verification

- All existing tests pass: ✅ (4692)
- New tests pass: ✅ (15)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*