### PR TITLE
fix(knowledge): assert embedding dim in allowlist before SQL interpolation (fixes #346)

### DIFF
--- a/agent_fox/engine/state.py
+++ b/agent_fox/engine/state.py
@@ -203,7 +203,6 @@ def update_state_with_session(
     return state
 
 
-
 def load_state_from_db(
     conn: duckdb.DuckDBPyConnection,
 ) -> ExecutionState | None:

--- a/agent_fox/knowledge/ingest.py
+++ b/agent_fox/knowledge/ingest.py
@@ -19,6 +19,7 @@ import duckdb
 
 from agent_fox.core.config import KnowledgeConfig
 from agent_fox.knowledge.embeddings import EmbeddingGenerator
+from agent_fox.knowledge.migrations import _ALLOWED_EMBEDDING_DIMS
 
 if TYPE_CHECKING:
     from agent_fox.knowledge.sink import SinkDispatcher
@@ -58,13 +59,13 @@ class KnowledgeIngestor:
 
         Returns True on success, False on failure (logged as warning).
         """
+        dim = self._embedder.embedding_dimensions
+        assert dim in _ALLOWED_EMBEDDING_DIMS, f"Invalid embedding dimension: {dim}"
         try:
             embedding = self._embedder.embed_text(text)
             if embedding is not None:
                 self._conn.execute(
-                    "INSERT INTO memory_embeddings (id, embedding) "
-                    "VALUES (?::UUID, ?::FLOAT"
-                    f"[{self._embedder.embedding_dimensions}])",
+                    f"INSERT INTO memory_embeddings (id, embedding) VALUES (?::UUID, ?::FLOAT[{dim}])",
                     [fact_id, embedding],
                 )
                 return True

--- a/agent_fox/knowledge/migrations.py
+++ b/agent_fox/knowledge/migrations.py
@@ -225,6 +225,7 @@ def _migrate_v5(conn: duckdb.DuckDBPyConnection) -> None:
     except Exception:
         pass
 
+    assert dim in _ALLOWED_EMBEDDING_DIMS, f"Invalid embedding dimension: {dim}"
     conn.execute(f"""
         CREATE TABLE memory_embeddings (
             id        UUID PRIMARY KEY REFERENCES memory_facts(id),
@@ -347,6 +348,7 @@ def _migrate_v10(conn: duckdb.DuckDBPyConnection) -> None:
     conn.execute("ALTER TABLE memory_facts ADD COLUMN keywords TEXT[] DEFAULT []")
 
     # Recreate memory_embeddings with FK restored
+    assert dim in _ALLOWED_EMBEDDING_DIMS, f"Invalid embedding dimension: {dim}"
     conn.execute(f"""
         CREATE TABLE memory_embeddings (
             id        UUID PRIMARY KEY REFERENCES memory_facts(id),

--- a/agent_fox/knowledge/store.py
+++ b/agent_fox/knowledge/store.py
@@ -22,6 +22,7 @@ import duckdb
 from agent_fox.core.models import ensure_iso
 from agent_fox.core.paths import DEFAULT_DB_PATH
 from agent_fox.knowledge.facts import Fact, parse_confidence
+from agent_fox.knowledge.migrations import _ALLOWED_EMBEDDING_DIMS
 
 if TYPE_CHECKING:
     from agent_fox.knowledge.embeddings import EmbeddingGenerator
@@ -302,6 +303,7 @@ class MemoryStore:
     def _write_embedding(self, fact_id: str, embedding: list[float]) -> None:
         """Insert an embedding into the DuckDB ``memory_embeddings`` table."""
         dim = self._embedder.embedding_dimensions if self._embedder is not None else len(embedding)
+        assert dim in _ALLOWED_EMBEDDING_DIMS, f"Invalid embedding dimension: {dim}"
         self._db_conn.execute(
             f"INSERT INTO memory_embeddings (id, embedding) VALUES (?::UUID, ?::FLOAT[{dim}])",
             [fact_id, embedding],

--- a/tests/unit/knowledge/test_hardening_store.py
+++ b/tests/unit/knowledge/test_hardening_store.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 import uuid
 from pathlib import Path
 from typing import get_type_hints
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import duckdb
 import pytest
 
 from agent_fox.knowledge.facts import Fact
+from agent_fox.knowledge.ingest import KnowledgeIngestor
 from agent_fox.knowledge.store import MemoryStore
 
 
@@ -87,3 +88,56 @@ class TestMemoryStorePropagation:
 
         with pytest.raises(duckdb.Error, match="DuckDB update failed"):
             store.mark_superseded("old-id", "new-id")
+
+
+class TestEmbeddingDimAllowlist:
+    """Verify embedding dimension interpolation is guarded by allowlist assertions.
+
+    Regression tests for issue #346 (SQL injection via f-string dim interpolation).
+    """
+
+    def test_write_embedding_raises_for_invalid_dim(self) -> None:
+        """Invalid embedding dimensions must be rejected before SQL interpolation."""
+        invalid_embedder = MagicMock()
+        invalid_embedder.embedding_dimensions = 999  # not in allowlist
+
+        mock_conn = MagicMock(spec=duckdb.DuckDBPyConnection)
+        store = MemoryStore(Path("/dev/null"), db_conn=mock_conn, embedder=invalid_embedder)
+
+        with pytest.raises(AssertionError, match="Invalid embedding dimension: 999"):
+            store._write_embedding(str(uuid.uuid4()), [0.0] * 999)
+
+        # The DB must NOT have been called — assertion fires before execute()
+        mock_conn.execute.assert_not_called()
+
+    @pytest.mark.parametrize("dim", [384, 768, 1536])
+    def test_write_embedding_allows_valid_dims(self, dim: int) -> None:
+        """Allowed embedding dimensions (384, 768, 1536) must not raise."""
+        valid_embedder = MagicMock()
+        valid_embedder.embedding_dimensions = dim
+
+        mock_conn = MagicMock(spec=duckdb.DuckDBPyConnection)
+        store = MemoryStore(Path("/dev/null"), db_conn=mock_conn, embedder=valid_embedder)
+
+        fact_id = str(uuid.uuid4())
+        embedding = [0.1] * dim
+        # Should not raise
+        store._write_embedding(fact_id, embedding)
+        mock_conn.execute.assert_called_once()
+
+    def test_ingest_store_embedding_raises_for_invalid_dim(
+        self, tmp_path: Path, schema_conn: duckdb.DuckDBPyConnection
+    ) -> None:
+        """KnowledgeIngestor._store_embedding rejects dimensions not in allowlist."""
+        invalid_embedder = MagicMock()
+        invalid_embedder.embedding_dimensions = 42  # not in allowlist
+        invalid_embedder.embed_text.return_value = [0.0] * 42
+
+        ingestor = KnowledgeIngestor(
+            conn=schema_conn,
+            embedder=invalid_embedder,
+            project_root=tmp_path,
+        )
+
+        with pytest.raises(AssertionError, match="Invalid embedding dimension: 42"):
+            ingestor._store_embedding(str(uuid.uuid4()), "test text", "label")


### PR DESCRIPTION
## Summary

Adds redundant `_ALLOWED_EMBEDDING_DIMS` assertions at all four embedding dimension f-string interpolation sites to eliminate the SQL injection vector described in issue #346. The assertion in `ingest.py` is placed before the `try/except` block so invalid dimensions propagate as hard failures rather than being swallowed silently.

Closes #346

## Changes

| File | Change |
|------|--------|
| `agent_fox/knowledge/store.py` | Import `_ALLOWED_EMBEDDING_DIMS`; assert before f-string in `_write_embedding` |
| `agent_fox/knowledge/ingest.py` | Import `_ALLOWED_EMBEDDING_DIMS`; assert before try block in `_store_embedding` |
| `agent_fox/knowledge/migrations.py` | Assert before each of the two f-string interpolation sites (belt-and-suspenders) |
| `tests/unit/knowledge/test_hardening_store.py` | Added `TestEmbeddingDimAllowlist` with 5 regression tests |

## Tests

- `test_write_embedding_raises_for_invalid_dim`: dim=999 raises `AssertionError` before DB is touched
- `test_write_embedding_allows_valid_dims[384/768/1536]`: all three allowed dims pass through
- `test_ingest_store_embedding_raises_for_invalid_dim`: dim=42 raises `AssertionError` in ingestor path

## Verification

- All existing tests pass: ✅ (4711 passed)
- New tests pass: ✅ (5 new tests)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*