### PR TITLE
fix(knowledge): add migration v13 to create blocking_history and learned_thresholds tables (fixes #449)

### DIFF
--- a/agent_fox/knowledge/migrations.py
+++ b/agent_fox/knowledge/migrations.py
@@ -508,6 +508,39 @@ def _migrate_v11(conn: duckdb.DuckDBPyConnection) -> None:
         logger.info("session_outcomes table not found, skipping session_outcomes extension in v11 migration")
 
 
+def _migrate_v13(conn: duckdb.DuckDBPyConnection) -> None:
+    """Add blocking_history and learned_thresholds tables.
+
+    These tables were referenced in agent_fox/knowledge/blocking_history.py
+    but never created in any migration or in the base schema DDL, causing a
+    CatalogException at runtime whenever a blocking decision was recorded.
+
+    Uses CREATE TABLE IF NOT EXISTS for idempotency.
+
+    Requirements: 39-REQ-10.1, 39-REQ-10.2, 39-REQ-10.3
+    """
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS blocking_history (
+            id            VARCHAR PRIMARY KEY,
+            spec_name     VARCHAR NOT NULL,
+            archetype     VARCHAR NOT NULL,
+            critical_count INTEGER NOT NULL,
+            threshold     INTEGER NOT NULL,
+            blocked       BOOLEAN NOT NULL,
+            outcome       VARCHAR,
+            created_at    TIMESTAMP DEFAULT current_timestamp
+        );
+
+        CREATE TABLE IF NOT EXISTS learned_thresholds (
+            archetype     VARCHAR PRIMARY KEY,
+            threshold     INTEGER NOT NULL,
+            confidence    FLOAT NOT NULL,
+            sample_count  INTEGER NOT NULL,
+            updated_at    TIMESTAMP DEFAULT current_timestamp
+        );
+    """)
+
+
 def _migrate_v12(conn: duckdb.DuckDBPyConnection) -> None:
     """Drop stale UNIQUE(spec_name, group_number) constraint from plan_nodes.
 
@@ -625,6 +658,11 @@ MIGRATIONS: list[Migration] = [
         version=12,
         description="drop stale UNIQUE(spec_name, group_number) from plan_nodes",
         apply=_migrate_v12,
+    ),
+    Migration(
+        version=13,
+        description="add blocking_history and learned_thresholds tables",
+        apply=_migrate_v13,
     ),
 ]
 
@@ -746,6 +784,25 @@ CREATE TABLE IF NOT EXISTS tool_errors (
     node_id    TEXT,
     tool_name  TEXT,
     failed_at  TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS blocking_history (
+    id            VARCHAR PRIMARY KEY,
+    spec_name     VARCHAR NOT NULL,
+    archetype     VARCHAR NOT NULL,
+    critical_count INTEGER NOT NULL,
+    threshold     INTEGER NOT NULL,
+    blocked       BOOLEAN NOT NULL,
+    outcome       VARCHAR,
+    created_at    TIMESTAMP DEFAULT current_timestamp
+);
+
+CREATE TABLE IF NOT EXISTS learned_thresholds (
+    archetype     VARCHAR PRIMARY KEY,
+    threshold     INTEGER NOT NULL,
+    confidence    FLOAT NOT NULL,
+    sample_count  INTEGER NOT NULL,
+    updated_at    TIMESTAMP DEFAULT current_timestamp
 );
 
 INSERT INTO schema_version (version, description)

--- a/tests/property/knowledge/test_db_props.py
+++ b/tests/property/knowledge/test_db_props.py
@@ -40,6 +40,9 @@ EXPECTED_TABLES = {
     "plan_edges",
     "plan_meta",
     "runs",
+    # Added by migration v13 (issue #449: blocking history)
+    "blocking_history",
+    "learned_thresholds",
 }
 
 
@@ -74,11 +77,12 @@ class TestSchemaInitializationIdempotency:
 
             version_count = db.connection.execute("SELECT COUNT(*) FROM schema_version").fetchone()
             assert version_count is not None
-            # v1..v12 (review, routing, drift, confidence, audit, security category,
+            # v1..v13 (review, routing, drift, confidence, audit, security category,
             #          entity graph, multi-language entity graph, keywords,
             #          plan_nodes/edges/meta/runs added by v11,
-            #          drop stale UNIQUE from plan_nodes in v12)
-            assert version_count[0] == 12
+            #          drop stale UNIQUE from plan_nodes in v12,
+            #          blocking_history and learned_thresholds in v13)
+            assert version_count[0] == 13
 
             tables = {r[0] for r in db.connection.execute("SHOW TABLES").fetchall()}
             assert tables == EXPECTED_TABLES

--- a/tests/property/knowledge/test_review_store_props.py
+++ b/tests/property/knowledge/test_review_store_props.py
@@ -112,10 +112,10 @@ class TestMigrationIdempotency:
         for _ in range(n_runs):
             apply_pending_migrations(conn)
 
-        # Version should be 12 (latest migration: v12 drop stale UNIQUE)
+        # Version should be 13 (latest migration: v13 blocking_history tables)
         version = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()
         assert version is not None
-        assert version[0] == 12
+        assert version[0] == 13
 
         # Tables should exist (v2 + v3 + v4 migrations)
         tables = conn.execute(

--- a/tests/unit/knowledge/test_blocking_history.py
+++ b/tests/unit/knowledge/test_blocking_history.py
@@ -342,3 +342,81 @@ class TestBlockingEdgeCases:
         threshold = compute_optimal_threshold(blocking_db, "skeptic", min_decisions=20)
         assert threshold is not None
         assert isinstance(threshold, int)
+
+
+# ---------------------------------------------------------------------------
+# Regression: migration v13 creates the tables in production schema
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationV13CreatesBlockingTables:
+    """Regression for issue #449: blocking_history table missing in production.
+
+    Verifies that run_migrations() creates blocking_history and
+    learned_thresholds so that record_blocking_decision() does not raise
+    CatalogException after review completion.
+    """
+
+    def test_run_migrations_creates_blocking_history(self) -> None:
+        """Regression #449: run_migrations creates blocking_history table."""
+        import duckdb as ddb
+
+        from agent_fox.knowledge.blocking_history import (
+            BlockingDecision,
+            record_blocking_decision,
+        )
+        from agent_fox.knowledge.migrations import run_migrations
+
+        conn = ddb.connect(":memory:")
+        run_migrations(conn)
+
+        # Must not raise CatalogException
+        decision = BlockingDecision(
+            spec_name="regression_449",
+            archetype="skeptic",
+            critical_count=2,
+            threshold=3,
+            blocked=False,
+            outcome="correct_pass",
+        )
+        record_blocking_decision(conn, decision)
+
+        rows = conn.execute("SELECT spec_name FROM blocking_history").fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "regression_449"
+
+    def test_run_migrations_creates_learned_thresholds(self) -> None:
+        """Regression #449: run_migrations creates learned_thresholds table."""
+        import duckdb as ddb
+
+        from agent_fox.knowledge.blocking_history import (
+            get_learned_threshold,
+            store_learned_threshold,
+        )
+        from agent_fox.knowledge.migrations import run_migrations
+
+        conn = ddb.connect(":memory:")
+        run_migrations(conn)
+
+        # Must not raise CatalogException
+        store_learned_threshold(conn, "skeptic", 4, 0.9, 30)
+        result = get_learned_threshold(conn, "skeptic")
+        assert result == 4
+
+    def test_tables_present_in_table_list(self) -> None:
+        """Regression #449: both tables appear in information_schema after migration."""
+        import duckdb as ddb
+
+        from agent_fox.knowledge.migrations import run_migrations
+
+        conn = ddb.connect(":memory:")
+        run_migrations(conn)
+
+        tables = {
+            r[0]
+            for r in conn.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+            ).fetchall()
+        }
+        assert "blocking_history" in tables, "blocking_history table missing after run_migrations()"
+        assert "learned_thresholds" in tables, "learned_thresholds table missing after run_migrations()"

--- a/tests/unit/knowledge/test_db.py
+++ b/tests/unit/knowledge/test_db.py
@@ -43,6 +43,9 @@ EXPECTED_TABLES = {
     "plan_edges",
     "plan_meta",
     "runs",
+    # Added by migration v13 (issue #449: blocking history)
+    "blocking_history",
+    "learned_thresholds",
 }
 
 
@@ -82,10 +85,10 @@ class TestSchemaVersionRecordedOnCreation:
         rows = db.connection.execute(
             "SELECT version, applied_at, description FROM schema_version ORDER BY version"
         ).fetchall()
-        # v1..v12 (review, routing, drift, confidence, audit, security category,
+        # v1..v13 (review, routing, drift, confidence, audit, security category,
         #          entity graph, multi-language entity graph, keywords, plan state,
-        #          drop stale UNIQUE from plan_nodes)
-        assert len(rows) == 12
+        #          drop stale UNIQUE from plan_nodes, blocking_history tables)
+        assert len(rows) == 13
         assert rows[0][0] == 1
         assert rows[0][1] is not None  # applied_at is a valid timestamp
         assert len(rows[0][2]) > 0  # description is non-empty
@@ -100,6 +103,7 @@ class TestSchemaVersionRecordedOnCreation:
         assert rows[9][0] == 10
         assert rows[10][0] == 11
         assert rows[11][0] == 12
+        assert rows[12][0] == 13
         db.close()
 
 
@@ -155,10 +159,10 @@ class TestSchemaInitializationIdempotent:
         db2.open()
         count = db2.connection.execute("SELECT COUNT(*) FROM schema_version").fetchone()
         assert count is not None
-        # v1..v12 (review, routing, drift, confidence, audit, security category,
+        # v1..v13 (review, routing, drift, confidence, audit, security category,
         #          entity graph, multi-language entity graph, keywords, plan state,
-        #          drop stale UNIQUE from plan_nodes)
-        assert count[0] == 12
+        #          drop stale UNIQUE from plan_nodes, blocking_history tables)
+        assert count[0] == 13
         db2.close()
 
 

--- a/tests/unit/knowledge/test_review_store.py
+++ b/tests/unit/knowledge/test_review_store.py
@@ -254,7 +254,7 @@ class TestMigrationAlreadyAppliedSkips:
         # Verify version is recorded
         version = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()
         assert version is not None
-        assert version[0] == 12
+        assert version[0] == 13
         conn.close()
 
 


### PR DESCRIPTION
## Summary

The `blocking_history` and `learned_thresholds` tables were referenced in `agent_fox/knowledge/blocking_history.py` but never created in any migration or the base schema DDL. This caused a recurring `CatalogException` in `result_handler.py:226` whenever a blocking decision was recorded after review completion, silently losing all blocking history data.

Closes #449

## Changes

| File | Change |
|------|--------|
| `agent_fox/knowledge/migrations.py` | Added `_migrate_v13` + registered in MIGRATIONS + added both tables to `_BASE_SCHEMA_DDL` |
| `tests/unit/knowledge/test_blocking_history.py` | Added `TestMigrationV13CreatesBlockingTables` with 3 regression tests |
| `tests/unit/knowledge/test_db.py` | Updated expected table list and version count (12 → 13) |
| `tests/unit/knowledge/test_review_store.py` | Updated hardcoded version assertion (12 → 13) |
| `tests/property/knowledge/test_db_props.py` | Updated expected table list and version count (12 → 13) |
| `tests/property/knowledge/test_review_store_props.py` | Updated hardcoded version assertion (12 → 13) |

## Tests

- `TestMigrationV13CreatesBlockingTables::test_run_migrations_creates_blocking_history`: verifies `record_blocking_decision()` does not raise `CatalogException` after `run_migrations()`
- `TestMigrationV13CreatesBlockingTables::test_run_migrations_creates_learned_thresholds`: verifies `store/get_learned_threshold()` works after `run_migrations()`
- `TestMigrationV13CreatesBlockingTables::test_tables_present_in_table_list`: verifies both tables appear in `information_schema` after migration

## Verification

- All existing tests pass: ✅ (9 pre-existing failures unchanged)
- New regression tests pass: ✅ (3 added, 4916 total passing vs 4913 baseline)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*