### PR TITLE
feat(knowledge): add cross-group knowledge retrieval (fixes #559)

### DIFF
--- a/agent_fox/core/config.py
+++ b/agent_fox/core/config.py
@@ -240,6 +240,7 @@ class KnowledgeProviderConfig(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     max_items: int = Field(default=10, description="Max total retrieval items")
+    max_cross_group_items: int = Field(default=3, description="Max cross-group retrieval items")
 
 
 class KnowledgeConfig(BaseModel):

--- a/agent_fox/knowledge/fox_provider.py
+++ b/agent_fox/knowledge/fox_provider.py
@@ -134,20 +134,31 @@ class FoxKnowledgeProvider:
         for text, id_ in zip(verdicts, verdict_ids):
             items_with_ids.append((text, id_))
 
+        # Cross-group items: findings and FAIL verdicts from other task groups
+        # in the same spec.  These are informational (not tracked for injection)
+        # and have their own cap (issue #559).
+        cross_group_items: list[str] = []
+        if task_group is not None:
+            cross_reviews = self._query_cross_group_reviews(conn, spec_name, task_group, task_description)
+            cross_verdicts = self._query_cross_group_verdicts(conn, spec_name, task_group, task_description)
+            cross_group_items = (cross_reviews + cross_verdicts)[: self._config.max_cross_group_items]
+
         capped = items_with_ids[: self._config.max_items]
-        result = [text for text, _ in capped]
+        result = [text for text, _ in capped] + cross_group_items
 
         logger.debug(
-            "Retrieved %d review + %d errata + %d ADR + %d verdict items for %s",
+            "Retrieved %d review + %d errata + %d ADR + %d verdict + %d cross-group items for %s",
             len(reviews),
             len(errata),
             len(adrs),
             len(verdicts),
+            len(cross_group_items),
             spec_name,
         )
 
         # Record which finding/verdict IDs were injected into this session so
         # that a successful ingest() can supersede them later (558-AC-1).
+        # Cross-group items are NOT tracked — they are informational context.
         if session_id:
             injected_ids = [id_ for _, id_ in capped if id_ is not None]
             if injected_ids:
@@ -321,6 +332,94 @@ class FoxKnowledgeProvider:
             result.append(f"[REVIEW] {' '.join(parts)}")
             ids.append(f.id)
         return result, ids
+
+    def _query_cross_group_reviews(
+        self,
+        conn: Any,
+        spec_name: str,
+        task_group: str,
+        task_description: str,
+    ) -> list[str]:
+        """Query active findings from *other* task groups in the same spec.
+
+        Returns formatted strings with a ``[CROSS-GROUP]`` prefix that includes
+        the source task group for context.  Uses the same relevance scoring as
+        same-group retrieval so the most relevant cross-group findings surface
+        first.
+
+        These items are informational — they are NOT tracked in
+        ``finding_injections`` and are not expected to be "fixed" by the
+        current session.
+        """
+        try:
+            from agent_fox.knowledge.review_store import query_cross_group_findings
+
+            findings = query_cross_group_findings(conn, spec_name, task_group)
+        except Exception:
+            logger.debug(
+                "Could not query cross-group findings for %s",
+                spec_name,
+            )
+            return []
+
+        keywords = _extract_keywords(task_description)
+        actionable = [f for f in findings if f.severity in ("critical", "major")]
+        actionable.sort(
+            key=lambda f: (
+                _SEVERITY_RANK.get(f.severity, 99),
+                -_score_relevance(f"{f.category or ''} {f.description}", keywords),
+                f.description,
+            )
+        )
+
+        result: list[str] = []
+        for f in actionable:
+            parts = [f"[{f.severity}]"]
+            if f.category:
+                parts.append(f"{f.category}:")
+            parts.append(f.description)
+            result.append(f"[CROSS-GROUP] (group {f.task_group}) {' '.join(parts)}")
+        return result
+
+    def _query_cross_group_verdicts(
+        self,
+        conn: Any,
+        spec_name: str,
+        task_group: str,
+        task_description: str,
+    ) -> list[str]:
+        """Query active FAIL verdicts from *other* task groups in the same spec.
+
+        Returns formatted strings with a ``[CROSS-GROUP]`` prefix.  Only FAIL
+        verdicts are returned — PASS verdicts are not actionable.
+        """
+        try:
+            from agent_fox.knowledge.review_store import query_cross_group_verdicts
+
+            verdicts = query_cross_group_verdicts(conn, spec_name, task_group)
+        except Exception:
+            logger.debug(
+                "Could not query cross-group verdicts for %s",
+                spec_name,
+            )
+            return []
+
+        keywords = _extract_keywords(task_description)
+        fail_verdicts = [v for v in verdicts if v.verdict == "FAIL"]
+        fail_verdicts.sort(
+            key=lambda v: (
+                -_score_relevance(f"{v.requirement_id} {v.evidence or ''}", keywords),
+                v.requirement_id,
+            )
+        )
+
+        result: list[str] = []
+        for v in fail_verdicts:
+            parts = [f"[FAIL] {v.requirement_id}"]
+            if v.evidence:
+                parts.append(v.evidence)
+            result.append(f"[CROSS-GROUP] (group {v.task_group}) {' '.join(parts)}")
+        return result
 
     def _query_errata(
         self,

--- a/agent_fox/knowledge/review_store.py
+++ b/agent_fox/knowledge/review_store.py
@@ -358,6 +358,45 @@ _DRIFT_COLS = (
 )
 
 
+def query_cross_group_findings(
+    conn: duckdb.DuckDBPyConnection,
+    spec_name: str,
+    task_group: str,
+) -> list[ReviewFinding]:
+    """Query non-superseded actionable findings from *other* task groups.
+
+    Returns findings where ``task_group != ?`` — i.e. everything except the
+    caller's own group.  Only ``critical`` and ``major`` findings are returned.
+    """
+    rows = conn.execute(
+        f"SELECT {_FINDING_COLS} FROM review_findings "  # noqa: S608
+        "WHERE spec_name = ? AND task_group != ? AND superseded_by IS NULL "
+        "ORDER BY severity, description",
+        [spec_name, task_group],
+    ).fetchall()
+    findings = [_row_to_finding(r) for r in rows if r[1] in ACTIONABLE_SEVERITIES]
+    findings.sort(key=lambda f: (_SEVERITY_ORDER.get(f.severity, 99), f.description))
+    return findings
+
+
+def query_cross_group_verdicts(
+    conn: duckdb.DuckDBPyConnection,
+    spec_name: str,
+    task_group: str,
+) -> list[VerificationResult]:
+    """Query non-superseded verdicts from *other* task groups.
+
+    Returns verdicts where ``task_group != ?``.
+    """
+    rows = conn.execute(
+        f"SELECT {_VERDICT_COLS} FROM verification_results "  # noqa: S608
+        "WHERE spec_name = ? AND task_group != ? AND superseded_by IS NULL "
+        "ORDER BY requirement_id",
+        [spec_name, task_group],
+    ).fetchall()
+    return [_row_to_verdict(r) for r in rows]
+
+
 def query_active_findings(
     conn: duckdb.DuckDBPyConnection,
     spec_name: str,

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,6 +1,15 @@
 # Agent-Fox Memory
 
-_3178 facts | last updated: 2026-04-27_
+_3179 facts | last updated: 2026-04-28_
+
+**2026-04-28 cross-group knowledge retrieval (issue #559):**
+`FoxKnowledgeProvider.retrieve()` now surfaces findings and FAIL verdicts from
+other task groups in the same spec with a `[CROSS-GROUP]` prefix. Cross-group
+items are capped separately (`max_cross_group_items`, default 3), ranked by
+keyword relevance (#557), and NOT tracked in `finding_injections` (they are
+informational context, not directives). Added `query_cross_group_findings()`
+and `query_cross_group_verdicts()` to `review_store.py`. Same-group behavior
+is unchanged. +10 tests (4518 total pass).
 
 **2026-04-27 Tier 1 code simplification:** Deleted dead `graph/critical_path.py`
 module (208 lines, zero production imports) and its 2 test files. Removed

--- a/tests/unit/knowledge/test_fox_provider.py
+++ b/tests/unit/knowledge/test_fox_provider.py
@@ -927,3 +927,226 @@ class TestRelevanceScoringVerdicts:
         assert "v1-REQ-LOG" in verify_items[1], (
             f"Expected logging verdict second, got: {verify_items[1]!r}"
         )
+
+
+# ===========================================================================
+# Issue #559: Cross-group knowledge retrieval
+# ===========================================================================
+
+
+def _insert_finding_for_group(
+    conn: duckdb.DuckDBPyConnection,
+    spec_name: str,
+    task_group: str,
+    description: str,
+    severity: str = "critical",
+    category: str | None = None,
+) -> str:
+    """Insert a finding tagged to a specific task_group. Returns the finding ID."""
+    finding_id = str(uuid.uuid4())
+    finding = ReviewFinding(
+        id=finding_id,
+        severity=severity,
+        description=description,
+        requirement_ref=None,
+        spec_name=spec_name,
+        task_group=task_group,
+        session_id="sess-setup",
+        category=category,
+    )
+    insert_findings(conn, [finding])
+    return finding_id
+
+
+class TestCrossGroupReviewRetrieval:
+    """Issue #559: cross-group findings are surfaced with [CROSS-GROUP] prefix.
+
+    When a session requests knowledge for task_group='2', it should also see
+    active critical/major findings from other groups (e.g. '1') in the same
+    spec, formatted with a distinct prefix to distinguish them from same-group
+    directives.
+    """
+
+    def test_cross_group_findings_appear_with_prefix(
+        self, provider_db, provider_conn
+    ) -> None:
+        """Findings from other groups appear with [CROSS-GROUP] prefix."""
+        _insert_finding_for_group(provider_conn, "spec_cg", "1", "tests use non-existent IDs")
+        _insert_finding_for_group(provider_conn, "spec_cg", "2", "same-group finding")
+
+        provider = _make_provider(provider_db)
+        result = provider.retrieve("spec_cg", "desc", task_group="2")
+
+        same_group = [r for r in result if r.startswith("[REVIEW]")]
+        cross_group = [r for r in result if r.startswith("[CROSS-GROUP]")]
+
+        assert len(same_group) == 1, f"Expected 1 same-group review, got: {same_group}"
+        assert "same-group finding" in same_group[0]
+        assert len(cross_group) == 1, f"Expected 1 cross-group item, got: {cross_group}"
+        assert "tests use non-existent IDs" in cross_group[0]
+
+    def test_cross_group_excludes_same_group(
+        self, provider_db, provider_conn
+    ) -> None:
+        """Cross-group items must not include findings from the requested group."""
+        _insert_finding_for_group(provider_conn, "spec_excl", "1", "group-1-finding")
+        _insert_finding_for_group(provider_conn, "spec_excl", "2", "group-2-finding")
+        _insert_finding_for_group(provider_conn, "spec_excl", "3", "group-3-finding")
+
+        provider = _make_provider(provider_db)
+        result = provider.retrieve("spec_excl", "desc", task_group="2")
+
+        cross_group = [r for r in result if r.startswith("[CROSS-GROUP]")]
+        cross_text = "\n".join(cross_group)
+
+        assert "group-1-finding" in cross_text
+        assert "group-3-finding" in cross_text
+        assert "group-2-finding" not in cross_text
+
+    def test_cross_group_respects_max_cross_group_items(
+        self, provider_db, provider_conn
+    ) -> None:
+        """Cross-group items are capped at max_cross_group_items."""
+        from agent_fox.core.config import KnowledgeProviderConfig
+
+        for i in range(10):
+            _insert_finding_for_group(
+                provider_conn, "spec_cap", f"other-{i}", f"finding-{i}"
+            )
+
+        config = KnowledgeProviderConfig(max_cross_group_items=3)
+        provider = _make_provider(provider_db, config=config)
+        result = provider.retrieve("spec_cap", "desc", task_group="5")
+
+        cross_group = [r for r in result if r.startswith("[CROSS-GROUP]")]
+        assert len(cross_group) == 3, (
+            f"Expected 3 cross-group items (cap), got {len(cross_group)}"
+        )
+
+    def test_cross_group_uses_relevance_scoring(
+        self, provider_db, provider_conn
+    ) -> None:
+        """Cross-group items are ranked by keyword overlap with task_description."""
+        from agent_fox.core.config import KnowledgeProviderConfig
+
+        _insert_finding_for_group(
+            provider_conn, "spec_rel", "1", "fix typo in docstring", severity="major"
+        )
+        _insert_finding_for_group(
+            provider_conn, "spec_rel", "1", "implement caching layer", severity="major"
+        )
+
+        config = KnowledgeProviderConfig(max_cross_group_items=1)
+        provider = _make_provider(provider_db, config=config)
+        result = provider.retrieve(
+            "spec_rel", "implement caching layer", task_group="2"
+        )
+
+        cross_group = [r for r in result if r.startswith("[CROSS-GROUP]")]
+        assert len(cross_group) == 1
+        assert "implement caching layer" in cross_group[0], (
+            f"Expected most relevant cross-group finding, got: {cross_group[0]!r}"
+        )
+
+    def test_cross_group_not_tracked_in_injections(
+        self, provider_db, provider_conn
+    ) -> None:
+        """Cross-group items must NOT be recorded in finding_injections."""
+        _insert_finding_for_group(provider_conn, "spec_inj", "1", "cross-group finding")
+
+        provider = _make_provider(provider_db)
+        provider.retrieve(
+            "spec_inj", "desc", task_group="2", session_id="test-session"
+        )
+
+        injections = provider_conn.execute(
+            "SELECT finding_id FROM finding_injections WHERE session_id = 'test-session'"
+        ).fetchall()
+        assert len(injections) == 0, (
+            f"Cross-group items should not be tracked in injections, found: {injections}"
+        )
+
+    def test_same_group_behavior_unchanged(
+        self, provider_db, provider_conn
+    ) -> None:
+        """Same-group retrieval is unchanged — [REVIEW] items still work as before."""
+        _insert_finding_for_group(provider_conn, "spec_same", "2", "same-group item")
+
+        provider = _make_provider(provider_db)
+        result = provider.retrieve("spec_same", "desc", task_group="2")
+
+        reviews = [r for r in result if r.startswith("[REVIEW]")]
+        cross = [r for r in result if r.startswith("[CROSS-GROUP]")]
+
+        assert len(reviews) == 1
+        assert "same-group item" in reviews[0]
+        assert len(cross) == 0
+
+    def test_no_cross_group_when_task_group_none(
+        self, provider_db, provider_conn
+    ) -> None:
+        """When task_group is None, all findings appear as [REVIEW] — no cross-group split."""
+        _insert_finding_for_group(provider_conn, "spec_none", "1", "group-1")
+        _insert_finding_for_group(provider_conn, "spec_none", "2", "group-2")
+
+        provider = _make_provider(provider_db)
+        result = provider.retrieve("spec_none", "desc", task_group=None)
+
+        reviews = [r for r in result if r.startswith("[REVIEW]")]
+        cross = [r for r in result if r.startswith("[CROSS-GROUP]")]
+
+        assert len(reviews) == 2
+        assert len(cross) == 0
+
+    def test_cross_group_includes_source_group(
+        self, provider_db, provider_conn
+    ) -> None:
+        """Cross-group items include the source task_group for context."""
+        _insert_finding_for_group(provider_conn, "spec_src", "1", "from-group-1")
+
+        provider = _make_provider(provider_db)
+        result = provider.retrieve("spec_src", "desc", task_group="3")
+
+        cross_group = [r for r in result if r.startswith("[CROSS-GROUP]")]
+        assert len(cross_group) == 1
+        assert "group 1" in cross_group[0], (
+            f"Expected source group reference, got: {cross_group[0]!r}"
+        )
+
+
+class TestCrossGroupVerdictRetrieval:
+    """Issue #559: cross-group FAIL verdicts are surfaced alongside cross-group findings."""
+
+    def test_cross_group_fail_verdict_appears(
+        self, provider_db, provider_conn
+    ) -> None:
+        """FAIL verdicts from other groups appear with [CROSS-GROUP] prefix."""
+        _insert_verdict(provider_conn, "spec_xv", "REQ-1", "FAIL", task_group="0", evidence="Not tested")
+        _insert_verdict(provider_conn, "spec_xv", "REQ-2", "PASS", task_group="0-pass")
+
+        provider = _make_provider(provider_db)
+        result = provider.retrieve("spec_xv", "desc", task_group="2")
+
+        cross_group = [r for r in result if r.startswith("[CROSS-GROUP]")]
+        assert len(cross_group) == 1, f"Expected 1 cross-group verdict, got: {cross_group}"
+        assert "REQ-1" in cross_group[0]
+        assert "REQ-2" not in "\n".join(cross_group)
+
+    def test_cross_group_verdicts_excluded_from_injections(
+        self, provider_db, provider_conn
+    ) -> None:
+        """Cross-group verdicts must NOT be tracked in finding_injections."""
+        _insert_verdict(
+            provider_conn, "spec_xvi", "REQ-X", "FAIL",
+            task_group="0", evidence="Missing"
+        )
+
+        provider = _make_provider(provider_db)
+        provider.retrieve(
+            "spec_xvi", "desc", task_group="2", session_id="test-session-v"
+        )
+
+        injections = provider_conn.execute(
+            "SELECT finding_id FROM finding_injections WHERE session_id = 'test-session-v'"
+        ).fetchall()
+        assert len(injections) == 0


### PR DESCRIPTION
## Summary

Surface findings and FAIL verdicts from other task groups in the same spec so that sessions in groups 2–N can learn from patterns found in earlier groups. Cross-group items use a distinct `[CROSS-GROUP]` prefix with source group attribution.

Closes #559

## Changes

| File | Change |
|------|--------|
| `agent_fox/knowledge/review_store.py` | Added `query_cross_group_findings()` and `query_cross_group_verdicts()` |
| `agent_fox/knowledge/fox_provider.py` | Added cross-group retrieval methods and wired into `retrieve()` |
| `agent_fox/core/config.py` | Added `max_cross_group_items: int = 3` to `KnowledgeProviderConfig` |
| `tests/unit/knowledge/test_fox_provider.py` | 10 new tests |
| `docs/memory.md` | Session note |

## Tests

- `TestCrossGroupReviewRetrieval` (8 tests): prefix, exclusion, cap, relevance, injection tracking, backward compat
- `TestCrossGroupVerdictRetrieval` (2 tests): FAIL verdict surfacing, injection exclusion

## Verification

- All existing tests pass: ✅ (4508 unchanged)
- New tests pass: ✅ (10 added, 4518 total)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*