### PR TITLE
fix(engine): wire audit_max_retries into audit-review retry logic (fixes #567)

### DIFF
--- a/agent_fox/engine/result_handler.py
+++ b/agent_fox/engine/result_handler.py
@@ -79,6 +79,9 @@ class SessionResultHandler:
         self._node_timeout: dict[str, int] = {}
         self._original_node_timeout: dict[str, int] = {}  # per-node original timeouts
 
+        # Audit-review retry counter (separate from the generic EscalationLadder)
+        self._audit_retry_counts: dict[str, int] = {}
+
         # Coverage regression gate state
         self._coverage_baselines: dict[str, Any] = {}
         self._coverage_tool: Any = None  # None = not checked, False = no tool
@@ -248,7 +251,7 @@ class SessionResultHandler:
             archetype_entry = resolve_effective_config(archetype_entry, node_mode)
 
         if archetype_entry.retry_predecessor:
-            return self._retry_on_review_block(record, decision, state)
+            return self._retry_on_review_block(record, decision, state, mode=node_mode)
 
         self._block_task(decision.coder_node_id, state, decision.reason)
         self._generate_errata(record)
@@ -259,19 +262,28 @@ class SessionResultHandler:
         record: SessionRecord,
         decision: Any,
         state: ExecutionState,
+        *,
+        mode: str | None = None,
     ) -> bool:
         """Convert a review block to a coder retry when retry_predecessor is set.
 
         Instead of permanently blocking the coder, lets it proceed with review
-        findings injected as context. Uses the coder's escalation ladder to
-        prevent infinite retries; permanently blocks when the ladder is exhausted.
+        findings injected as context.
 
-        Returns True if the coder was permanently blocked (ladder exhausted),
+        For audit-review mode, uses a dedicated per-node counter capped by
+        ``ReviewerConfig.audit_max_retries`` so audit retries do not consume
+        the coder's generic escalation budget. For other modes, falls back to
+        the coder's ``EscalationLadder``.
+
+        Returns True if the coder was permanently blocked (retries exhausted),
         False if converted to a retry.
         """
-        from agent_fox.core.escalation import EscalationLadder
-
         coder_node_id = decision.coder_node_id
+
+        if mode == "audit-review":
+            return self._retry_on_audit_review_block(record, decision, state, coder_node_id)
+
+        from agent_fox.core.escalation import EscalationLadder
 
         pred_ladder = self._routing_ladders.get(coder_node_id)
         if pred_ladder is None:
@@ -314,6 +326,83 @@ class SessionResultHandler:
                 "to_status": "retry_predecessor",
                 "reason": decision.reason,
                 "coder_node_id": coder_node_id,
+            },
+        )
+
+        if self._task_callback is not None:
+            self._task_callback(
+                TaskEvent(
+                    node_id=record.node_id,
+                    status="disagreed",
+                    duration_s=0,
+                    archetype=self._get_node_archetype(record.node_id),
+                    predecessor_node=coder_node_id,
+                )
+            )
+
+        self._generate_errata(record)
+        return False
+
+    def _get_audit_max_retries(self) -> int:
+        """Read audit_max_retries from ReviewerConfig, defaulting to 2."""
+        if self._archetypes_config is not None:
+            return self._archetypes_config.reviewer_config.audit_max_retries
+        return 2
+
+    def _retry_on_audit_review_block(
+        self,
+        record: SessionRecord,
+        decision: Any,
+        state: ExecutionState,
+        coder_node_id: str,
+    ) -> bool:
+        """Handle audit-review retry using a dedicated counter.
+
+        Uses ``ReviewerConfig.audit_max_retries`` instead of the generic
+        ``EscalationLadder`` so audit retries do not consume the coder's
+        escalation budget.
+
+        Returns True if permanently blocked, False if converted to retry.
+        """
+        max_retries = self._get_audit_max_retries()
+        count = self._audit_retry_counts.get(coder_node_id, 0)
+
+        if count >= max_retries:
+            logger.warning(
+                "Audit-review retries exhausted for %s (%d/%d), permanently blocking",
+                coder_node_id,
+                count,
+                max_retries,
+            )
+            self._block_task(coder_node_id, state, decision.reason)
+            self._generate_errata(record)
+            return True
+
+        self._audit_retry_counts[coder_node_id] = count + 1
+
+        logger.info(
+            "Audit-review blocking converted to retry for %s (%d/%d, findings injected as context)",
+            coder_node_id,
+            count + 1,
+            max_retries,
+        )
+        coder_status = self._graph_sync.node_states.get(coder_node_id)
+        if coder_status == "completed":
+            self._graph_sync._transition(coder_node_id, "pending", reason="retry after audit-review block")
+            self._graph_sync._transition(record.node_id, "pending", reason="retry after audit-review block")
+
+        emit_audit_event(
+            self._sink,
+            self._run_id,
+            AuditEventType.TASK_STATUS_CHANGE,
+            node_id=record.node_id,
+            payload={
+                "from_status": "completed",
+                "to_status": "retry_predecessor",
+                "reason": decision.reason,
+                "coder_node_id": coder_node_id,
+                "audit_retry_count": count + 1,
+                "audit_max_retries": max_retries,
             },
         )
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -324,7 +324,7 @@ Reviewer-specific configuration, consolidating settings for all review modes.
 | `pre_review_block_threshold` | int | `1` | >= 0 | Finding count to block merge for pre-review mode |
 | `drift_review_block_threshold` | int\|null | `null` | >= 1 | Drift count to block for drift-review mode; `null` = advisory only |
 | `audit_min_ts_entries` | int | `5` | >= 1 | Minimum test-spec entries to trigger audit-review injection |
-| `audit_max_retries` | int | `2` | >= 0 | Maximum audit-review retry iterations |
+| `audit_max_retries` | int | `2` | >= 0 | Maximum audit-review/coder retry cycles before permanently blocking. Tracked independently of the generic escalation ladder, so audit retries do not consume the coder's escalation budget. Set to 0 to block on the first audit-review failure |
 
 **Example:**
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,6 +1,13 @@
 # Agent-Fox Memory
 
-_3180 facts | last updated: 2026-04-29_
+_3181 facts | last updated: 2026-04-29_
+
+**2026-04-29 Wire audit_max_retries (issue #567):** `ReviewerConfig.audit_max_retries`
+was defined but never read by the retry logic. Added a dedicated per-coder-node
+counter (`_audit_retry_counts`) and `_retry_on_audit_review_block()` method in
+`SessionResultHandler` so audit-review retries are tracked independently of the
+generic `EscalationLadder`. Pre-review and drift-review modes are unaffected.
++4 tests (4635 total pass).
 
 **2026-04-29 Tier 1+2b code simplification:** Eliminated two single-file
 packages and merged one single-implementation protocol. Moved

--- a/tests/unit/engine/test_audit_review_blocking.py
+++ b/tests/unit/engine/test_audit_review_blocking.py
@@ -96,9 +96,7 @@ class TestAC1EvaluateReviewBlockingReturnsBlock:
     """AC-1: evaluate_review_blocking with mode='audit-review' blocks on
     critical/major findings with category='audit'."""
 
-    def test_critical_audit_finding_triggers_block(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_critical_audit_finding_triggers_block(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """Single critical audit finding → should_block=True, coder_node_id='foo:2'."""
         finding = _make_audit_finding(
             severity="critical",
@@ -114,9 +112,7 @@ class TestAC1EvaluateReviewBlockingReturnsBlock:
         assert decision.coder_node_id == "foo:2"
         assert decision.reason  # non-empty
 
-    def test_major_audit_finding_triggers_block(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_major_audit_finding_triggers_block(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """Major-severity audit finding also triggers blocking (not critical-only)."""
         finding = _make_audit_finding(
             severity="major",
@@ -132,9 +128,7 @@ class TestAC1EvaluateReviewBlockingReturnsBlock:
         assert decision.should_block is True
         assert decision.coder_node_id == "foo:2"
 
-    def test_reason_includes_finding_count_and_description(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_reason_includes_finding_count_and_description(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """Blocking reason includes finding count and truncated description."""
         finding = _make_audit_finding(
             description="Tests do not assert HTTP status code after POST",
@@ -150,9 +144,7 @@ class TestAC1EvaluateReviewBlockingReturnsBlock:
         assert "1" in decision.reason
         assert "foo:2" in decision.reason
 
-    def test_multiple_audit_findings_all_count(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_multiple_audit_findings_all_count(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """Multiple audit findings all contribute to the reason summary."""
         findings = [
             _make_audit_finding(
@@ -191,18 +183,14 @@ class TestAC2EvaluateReviewBlockingNoBlock:
     """AC-2: evaluate_review_blocking with mode='audit-review' does not block
     when no critical/major audit findings exist."""
 
-    def test_empty_db_returns_no_block(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_empty_db_returns_no_block(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """Empty review_findings table → should_block=False."""
         record = _make_audit_review_record()
         decision = evaluate_review_blocking(record, None, audit_conn, mode="audit-review")
 
         assert decision.should_block is False
 
-    def test_superseded_finding_does_not_block(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_superseded_finding_does_not_block(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """Superseded audit finding is excluded → should_block=False."""
         # Insert a critical audit finding, then supersede it
         old_id = str(uuid.uuid4())
@@ -226,9 +214,7 @@ class TestAC2EvaluateReviewBlockingNoBlock:
 
         assert decision.should_block is False
 
-    def test_non_audit_category_does_not_trigger_block(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_non_audit_category_does_not_trigger_block(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """Critical finding with category='security' (not 'audit') is ignored."""
         finding = _make_audit_finding(
             severity="critical",
@@ -243,9 +229,7 @@ class TestAC2EvaluateReviewBlockingNoBlock:
 
         assert decision.should_block is False
 
-    def test_wrong_task_group_does_not_block(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_wrong_task_group_does_not_block(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """Audit finding for task_group='3' does not block coder for group 2."""
         finding = _make_audit_finding(
             severity="critical",
@@ -261,9 +245,7 @@ class TestAC2EvaluateReviewBlockingNoBlock:
 
         assert decision.should_block is False
 
-    def test_fix_review_mode_never_blocks(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_fix_review_mode_never_blocks(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """fix-review mode is excluded from blocking even with audit findings."""
         finding = _make_audit_finding(
             severity="critical",
@@ -351,6 +333,7 @@ def _make_audit_review_handler(
     block_task_fn = MagicMock()
     archetypes_config = MagicMock()
     archetypes_config.reviewer_config.pre_review_block_threshold = 1
+    archetypes_config.reviewer_config.audit_max_retries = 2
 
     handler = SessionResultHandler(
         graph_sync=graph_sync,
@@ -380,9 +363,7 @@ def _make_audit_review_handler(
 class TestAC3CheckSkepticBlockingForAuditReview:
     """AC-3: check_skeptic_blocking triggers retry_predecessor for audit-review."""
 
-    def test_audit_review_blocking_resets_coder_to_pending(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_audit_review_blocking_resets_coder_to_pending(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """When audit findings block, the coder is reset to pending (not permanently blocked)."""
         finding = _make_audit_finding(
             severity="critical",
@@ -403,9 +384,7 @@ class TestAC3CheckSkepticBlockingForAuditReview:
         assert handler._graph_sync.node_states.get("foo:2") == "pending"
         assert handler._graph_sync.node_states.get("foo:2:reviewer:audit-review") == "pending"
 
-    def test_no_audit_findings_does_not_trigger_retry(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_no_audit_findings_does_not_trigger_retry(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """Empty audit findings → no blocking, coder stays completed."""
         handler, state, block_task_fn = _make_audit_review_handler(audit_conn)
         record = _make_audit_review_record(node_id="foo:2:reviewer:audit-review")
@@ -434,9 +413,7 @@ class TestAC4BuildRetryContextIncludesAuditFindings:
     """AC-4: build_retry_context() includes active audit findings for the
     matching (spec_name, task_group)."""
 
-    def test_critical_audit_finding_included_in_retry_context(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_critical_audit_finding_included_in_retry_context(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """build_retry_context returns non-empty string with the audit finding."""
         from agent_fox.engine.session_lifecycle import build_retry_context
 
@@ -457,9 +434,7 @@ class TestAC4BuildRetryContextIncludesAuditFindings:
         assert ctx, "build_retry_context must return non-empty string when audit findings exist"
         assert "Test does not assert DB state after insert" in ctx
 
-    def test_major_audit_finding_included(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_major_audit_finding_included(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """Major-severity audit findings are also included in the retry context."""
         from agent_fox.engine.session_lifecycle import build_retry_context
 
@@ -479,9 +454,7 @@ class TestAC4BuildRetryContextIncludesAuditFindings:
         assert ctx
         assert "Assertions are too shallow" in ctx
 
-    def test_wrong_task_group_finding_excluded(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_wrong_task_group_finding_excluded(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """Audit finding for task_group='3' is excluded when querying for group 2."""
         from agent_fox.engine.session_lifecycle import build_retry_context
 
@@ -500,13 +473,10 @@ class TestAC4BuildRetryContextIncludesAuditFindings:
         ctx = build_retry_context(_MockKnowledgeDB(), "foo", task_group="2")  # type: ignore[arg-type]
 
         assert ctx == "", (
-            "Findings for task_group='3' must not appear when build_retry_context "
-            "is called with task_group='2'"
+            "Findings for task_group='3' must not appear when build_retry_context is called with task_group='2'"
         )
 
-    def test_no_findings_returns_empty_string(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_no_findings_returns_empty_string(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """Empty finding table → build_retry_context returns empty string."""
         from agent_fox.engine.session_lifecycle import build_retry_context
 
@@ -527,13 +497,8 @@ class TestAC5ExhaustedLadderBlocksPermanently:
     """AC-5: When the predecessor coder's EscalationLadder is exhausted,
     _retry_on_review_block permanently blocks the coder instead of looping."""
 
-    def test_exhausted_ladder_permanently_blocks_coder(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
-        """After the ladder is exhausted, the coder is blocked (not reset to pending)."""
-        from agent_fox.core.models import ModelTier
-        from agent_fox.core.escalation import EscalationLadder
-
+    def test_exhausted_audit_retries_permanently_blocks_coder(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
+        """After audit_max_retries is exhausted, the coder is blocked (not reset to pending)."""
         finding = _make_audit_finding(
             severity="critical",
             spec_name="foo",
@@ -543,30 +508,18 @@ class TestAC5ExhaustedLadderBlocksPermanently:
 
         handler, state, block_task_fn = _make_audit_review_handler(audit_conn)
 
-        # Pre-exhaust the coder's ladder so the next failure permanently blocks
-        exhausted_ladder = EscalationLadder(
-            starting_tier=ModelTier.STANDARD,
-            tier_ceiling=ModelTier.ADVANCED,
-            retries_before_escalation=1,
-        )
-        # Record enough failures to exhaust the ladder
-        while not exhausted_ladder.is_exhausted:
-            exhausted_ladder.record_failure()
-
-        assert exhausted_ladder.is_exhausted, "Ladder must be exhausted before test assertion"
-        handler._routing_ladders["foo:2"] = exhausted_ladder
+        # Pre-exhaust the audit retry counter (audit_max_retries=2)
+        handler._audit_retry_counts["foo:2"] = 2
 
         record = _make_audit_review_record(node_id="foo:2:reviewer:audit-review")
         handler.check_skeptic_blocking(record, state)
 
-        # With exhausted ladder, the coder should be permanently blocked
+        # With exhausted audit counter, the coder should be permanently blocked
         block_task_fn.assert_called_once()
         blocked_node_id = block_task_fn.call_args[0][0]
         assert blocked_node_id == "foo:2"
 
-    def test_non_exhausted_ladder_still_retries(
-        self, audit_conn: duckdb.DuckDBPyConnection
-    ) -> None:
+    def test_non_exhausted_ladder_still_retries(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
         """With a fresh ladder, the coder is reset to pending (not permanently blocked)."""
         finding = _make_audit_finding(
             severity="critical",
@@ -583,3 +536,276 @@ class TestAC5ExhaustedLadderBlocksPermanently:
         # Fresh ladder → convert to retry, not permanent block
         block_task_fn.assert_not_called()
         assert state.node_states["foo:2"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# AC-6: audit_max_retries from ReviewerConfig controls the audit-review
+#        retry limit independently of the generic EscalationLadder.
+# ---------------------------------------------------------------------------
+
+
+def _make_audit_handler_with_config(
+    audit_conn: duckdb.DuckDBPyConnection,
+    audit_max_retries: int = 2,
+    retries_before_escalation: int = 5,
+) -> tuple[SessionResultHandler, ExecutionState, MagicMock]:
+    """Build a handler where audit_max_retries and retries_before_escalation differ."""
+    node_states: dict[str, str] = {
+        "foo:2": "completed",
+        "foo:2:reviewer:audit-review": "completed",
+    }
+    edges_dict: dict[str, list[str]] = {
+        "foo:2": [],
+        "foo:2:reviewer:audit-review": ["foo:2"],
+    }
+
+    graph_sync = MagicMock()
+    graph_sync.node_states = node_states
+    graph_sync.predecessors = lambda nid: edges_dict.get(nid, [])
+
+    def _transition(nid: str, new_status: str, *, reason: str = "") -> None:
+        node_states[nid] = new_status
+
+    graph_sync._transition.side_effect = _transition
+
+    graph = TaskGraph(
+        nodes={
+            "foo:2": Node(
+                id="foo:2",
+                spec_name="foo",
+                group_number=2,
+                title="Write tests",
+                optional=False,
+                archetype="coder",
+            ),
+            "foo:2:reviewer:audit-review": Node(
+                id="foo:2:reviewer:audit-review",
+                spec_name="foo",
+                group_number=2,
+                title="Reviewer (audit-review)",
+                optional=False,
+                archetype="reviewer",
+                mode="audit-review",
+            ),
+        },
+        edges=[
+            Edge(
+                source="foo:2",
+                target="foo:2:reviewer:audit-review",
+                kind="intra_spec",
+            )
+        ],
+        order=["foo:2", "foo:2:reviewer:audit-review"],
+    )
+
+    block_task_fn = MagicMock()
+    archetypes_config = MagicMock()
+    archetypes_config.reviewer_config.pre_review_block_threshold = 1
+    archetypes_config.reviewer_config.audit_max_retries = audit_max_retries
+
+    handler = SessionResultHandler(
+        graph_sync=graph_sync,
+        routing_ladders={},
+        retries_before_escalation=retries_before_escalation,
+        max_retries=10,
+        task_callback=None,
+        sink=None,
+        run_id="test-run",
+        graph=graph,
+        archetypes_config=archetypes_config,
+        knowledge_db_conn=audit_conn,
+        block_task_fn=block_task_fn,
+        check_block_budget_fn=MagicMock(),
+    )
+
+    state = ExecutionState(
+        plan_hash="test",
+        node_states=node_states,
+        started_at="2026-01-01",
+        updated_at="2026-01-01",
+    )
+
+    return handler, state, block_task_fn
+
+
+class TestAC6AuditMaxRetriesConfig:
+    """AC-6: audit_max_retries from ReviewerConfig controls audit-review retry
+    limit independently of the generic EscalationLadder."""
+
+    def test_audit_retries_limited_by_audit_max_retries(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
+        """After audit_max_retries (2) cycles, coder is permanently blocked."""
+        finding = _make_audit_finding(severity="critical", spec_name="foo", task_group="2")
+        insert_findings(audit_conn, [finding])
+
+        handler, state, block_task_fn = _make_audit_handler_with_config(
+            audit_conn, audit_max_retries=2, retries_before_escalation=5
+        )
+
+        record = _make_audit_review_record(node_id="foo:2:reviewer:audit-review")
+
+        # First two retries should succeed (convert to pending)
+        for i in range(2):
+            state.node_states["foo:2"] = "completed"
+            state.node_states["foo:2:reviewer:audit-review"] = "completed"
+            handler._graph_sync.node_states["foo:2"] = "completed"
+            handler._graph_sync.node_states["foo:2:reviewer:audit-review"] = "completed"
+            blocked = handler.check_skeptic_blocking(record, state)
+            assert blocked is False, f"Retry {i + 1} should convert to retry, not block"
+            block_task_fn.assert_not_called()
+
+        # Third attempt should permanently block
+        state.node_states["foo:2"] = "completed"
+        state.node_states["foo:2:reviewer:audit-review"] = "completed"
+        handler._graph_sync.node_states["foo:2"] = "completed"
+        handler._graph_sync.node_states["foo:2:reviewer:audit-review"] = "completed"
+        blocked = handler.check_skeptic_blocking(record, state)
+        assert blocked is True, "After audit_max_retries exhausted, coder must be permanently blocked"
+        block_task_fn.assert_called_once()
+
+    def test_audit_retries_do_not_consume_escalation_ladder(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
+        """Audit retries should not consume the coder's generic EscalationLadder budget."""
+        finding = _make_audit_finding(severity="critical", spec_name="foo", task_group="2")
+        insert_findings(audit_conn, [finding])
+
+        handler, state, block_task_fn = _make_audit_handler_with_config(
+            audit_conn, audit_max_retries=1, retries_before_escalation=5
+        )
+
+        record = _make_audit_review_record(node_id="foo:2:reviewer:audit-review")
+
+        # One retry allowed
+        state.node_states["foo:2"] = "completed"
+        handler._graph_sync.node_states["foo:2"] = "completed"
+        handler.check_skeptic_blocking(record, state)
+        block_task_fn.assert_not_called()
+
+        # The coder's generic escalation ladder should not have been created/consumed
+        assert "foo:2" not in handler._routing_ladders, (
+            "Audit retries must not create or consume the coder's generic EscalationLadder"
+        )
+
+    def test_audit_max_retries_zero_blocks_immediately(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
+        """With audit_max_retries=0, the very first audit block permanently blocks."""
+        finding = _make_audit_finding(severity="critical", spec_name="foo", task_group="2")
+        insert_findings(audit_conn, [finding])
+
+        handler, state, block_task_fn = _make_audit_handler_with_config(audit_conn, audit_max_retries=0)
+
+        record = _make_audit_review_record(node_id="foo:2:reviewer:audit-review")
+        blocked = handler.check_skeptic_blocking(record, state)
+
+        assert blocked is True
+        block_task_fn.assert_called_once()
+
+    def test_pre_review_still_uses_escalation_ladder(self, audit_conn: duckdb.DuckDBPyConnection) -> None:
+        """Pre-review mode (not audit-review) still uses the generic EscalationLadder."""
+        from agent_fox.knowledge.review_store import ReviewFinding
+
+        finding = ReviewFinding(
+            id=str(uuid.uuid4()),
+            severity="critical",
+            description="Security issue",
+            requirement_ref=None,
+            spec_name="foo",
+            task_group="1",
+            session_id="foo:0:reviewer:pre-review:1",
+            category="security",
+        )
+        insert_findings(audit_conn, [finding])
+
+        node_states: dict[str, str] = {
+            "foo:0:reviewer:pre-review": "completed",
+            "foo:1": "completed",
+        }
+        edges_dict: dict[str, list[str]] = {
+            "foo:0:reviewer:pre-review": [],
+            "foo:1": ["foo:0:reviewer:pre-review"],
+        }
+        graph_sync = MagicMock()
+        graph_sync.node_states = node_states
+        graph_sync.predecessors = lambda nid: edges_dict.get(nid, [])
+
+        def _transition(nid: str, new_status: str, *, reason: str = "") -> None:
+            node_states[nid] = new_status
+
+        graph_sync._transition.side_effect = _transition
+
+        graph = TaskGraph(
+            nodes={
+                "foo:0:reviewer:pre-review": Node(
+                    id="foo:0:reviewer:pre-review",
+                    spec_name="foo",
+                    group_number=0,
+                    title="Pre-review",
+                    optional=False,
+                    archetype="reviewer",
+                    mode="pre-review",
+                ),
+                "foo:1": Node(
+                    id="foo:1",
+                    spec_name="foo",
+                    group_number=1,
+                    title="Coder",
+                    optional=False,
+                    archetype="coder",
+                ),
+            },
+            edges=[Edge(source="foo:0:reviewer:pre-review", target="foo:1", kind="intra_spec")],
+            order=["foo:0:reviewer:pre-review", "foo:1"],
+        )
+
+        block_task_fn = MagicMock()
+        archetypes_config = MagicMock()
+        archetypes_config.reviewer_config.pre_review_block_threshold = 1
+        archetypes_config.reviewer_config.audit_max_retries = 0
+
+        handler = SessionResultHandler(
+            graph_sync=graph_sync,
+            routing_ladders={},
+            retries_before_escalation=2,
+            max_retries=3,
+            task_callback=None,
+            sink=None,
+            run_id="test-run",
+            graph=graph,
+            archetypes_config=archetypes_config,
+            knowledge_db_conn=audit_conn,
+            block_task_fn=block_task_fn,
+            check_block_budget_fn=MagicMock(),
+        )
+
+        state = ExecutionState(
+            plan_hash="test",
+            node_states=node_states,
+            started_at="2026-01-01",
+            updated_at="2026-01-01",
+        )
+
+        record = _make_audit_review_record(
+            node_id="foo:0:reviewer:pre-review",
+        )
+        record = SessionRecord(
+            node_id="foo:0:reviewer:pre-review",
+            archetype="reviewer",
+            attempt=1,
+            status="completed",
+            input_tokens=0,
+            output_tokens=0,
+            cost=0.0,
+            duration_ms=0,
+            error_message=None,
+            timestamp="2026-01-01T00:00:00",
+        )
+
+        # Suppress errata file generation (side effect that pollutes the working tree)
+        handler._generate_errata = MagicMock()
+
+        # Pre-review with retry_predecessor=True should use the escalation ladder,
+        # not audit_max_retries. audit_max_retries=0 would block immediately if
+        # the code incorrectly applied it to pre-review.
+        blocked = handler.check_skeptic_blocking(record, state)
+
+        assert blocked is False, (
+            "Pre-review should use the generic EscalationLadder (retries_before_escalation=2), not audit_max_retries=0"
+        )
+        block_task_fn.assert_not_called()


### PR DESCRIPTION
## Summary

Wires the existing but dead `ReviewerConfig.audit_max_retries` config field into the audit-review retry logic by adding a dedicated per-coder-node counter in `SessionResultHandler`. Audit-review retries no longer consume the generic `EscalationLadder` budget, so the coder retains its escalation capacity for genuine coding failures.

Closes #567

## Changes

| File | Change |
|------|--------|
| `agent_fox/engine/result_handler.py` | Added `_audit_retry_counts` dict, `_get_audit_max_retries()`, and `_retry_on_audit_review_block()`. Modified `_retry_on_review_block()` to dispatch to audit-specific path. Passed `mode` from `check_skeptic_blocking()`. |
| `tests/unit/engine/test_audit_review_blocking.py` | Added `TestAC6AuditMaxRetriesConfig` (4 tests). Updated AC-5 test for new audit counter. Fixed mock setup. |
| `docs/config-reference.md` | Updated `audit_max_retries` description. |
| `docs/memory.md` | Added session entry. |

## Tests

- `test_audit_retries_limited_by_audit_max_retries`: Coder blocked after exactly `audit_max_retries` cycles
- `test_audit_retries_do_not_consume_escalation_ladder`: Generic ladder not created/consumed
- `test_audit_max_retries_zero_blocks_immediately`: Immediate block with `audit_max_retries=0`
- `test_pre_review_still_uses_escalation_ladder`: Pre-review mode unaffected

## Verification

- All existing tests pass: ✅ (4635 total, 4 new)
- Linter / formatter: ✅
- No regressions: ✅