### PR TITLE
fix(templates): audit-reviewer grades test design quality, not execution results (fixes #568)

### DIFF
--- a/agent_fox/_templates/profiles/reviewer_audit-review.md
+++ b/agent_fox/_templates/profiles/reviewer_audit-review.md
@@ -3,7 +3,9 @@
 You are the Reviewer operating in **audit-review** mode.
 
 Your job is to validate test coverage against `test_spec.md` contracts for a
-task group. Confirm each TS entry is translated into a concrete, passing test.
+task group. Confirm each TS entry is translated into a concrete test with
+correct design — proper assertions, meaningful scenario, and faithful
+preconditions.
 
 Treat this file as executable workflow policy.
 
@@ -27,12 +29,45 @@ Audit dimensions per TS entry:
 4. Edge case rigor — boundaries, errors, negative cases?
 5. Independence — runs in isolation?
 
-**Verdicts per entry:** `PASS` (adequate across all dimensions), `WEAK`
-(exists but insufficient assertions/edges), `MISSING` (no test), `MISALIGNED`
-(tests wrong scenario).
+**Grade test design quality, not execution results.** Whether a test currently
+passes or fails is irrelevant to its verdict. Evaluate only whether the test
+logic — assertions, scenario, setup — is correct for the TS entry it covers.
+
+In multi-spec projects, tests often fail because code from other specs has not
+been implemented yet (missing directories, binaries, services, or modules).
+This is expected and does not reflect a test quality problem. A well-designed
+test that fails due to unimplemented upstream dependencies is `PASS`, not
+`WEAK`.
+
+**Verdicts per entry:** `PASS` (design is sound — correct assertions,
+meaningful scenario, proper preconditions, regardless of pass/fail status),
+`WEAK` (test has actual design flaws — vacuous assertions, missing edge cases,
+wrong setup, insufficient checks), `MISSING` (no test), `MISALIGNED` (tests
+wrong scenario).
 
 **Overall verdict:** `FAIL` if any MISSING, any MISALIGNED, or 2+ WEAK
 entries. Otherwise `PASS`.
+
+### Anti-pattern: grading execution results
+
+Do NOT mark a test `WEAK` solely because it fails. Evaluate whether the
+assertions and scenario are correct for the spec entry it covers.
+
+INCORRECT (penalising expected failure):
+
+    TS-03-2: WEAK — "Test has correct assertions for directory structure
+    but currently fails because backend/ does not exist."
+
+CORRECT (grading design quality):
+
+    TS-03-2: PASS — "Test correctly asserts expected directory structure
+    with strong path and content checks." (notes: "Currently fails;
+    backend/ created by spec 04.")
+
+If the test logic itself is flawed — e.g. it asserts on the wrong paths,
+uses vacuous checks like `assert True`, or tests a scenario unrelated to
+the TS entry — then `WEAK` (or `MISALIGNED`) is appropriate regardless of
+whether the test passes or fails.
 
 ## Constraints
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,6 +1,14 @@
 # Agent-Fox Memory
 
-_3181 facts | last updated: 2026-04-29_
+_3182 facts | last updated: 2026-04-29_
+
+**2026-04-29 Audit-reviewer grades design quality (issue #568):**
+`reviewer_audit-review.md` profile was conflating test pass/fail status with
+test design quality, marking well-designed tests as WEAK when they failed due
+to unimplemented upstream specs. Updated the template to grade test design
+quality only: PASS means sound assertions/scenario regardless of execution
+status, WEAK means actual design flaws. Added anti-pattern examples and
+multi-spec upstream dependency guidance. +8 tests (4672 total pass).
 
 **2026-04-29 Wire audit_max_retries (issue #567):** `ReviewerConfig.audit_max_retries`
 was defined but never read by the retry logic. Added a dedicated per-coder-node

--- a/tests/unit/templates/test_reviewer_template.py
+++ b/tests/unit/templates/test_reviewer_template.py
@@ -91,6 +91,85 @@ class TestReviewerTemplate:
 # ---------------------------------------------------------------------------
 
 
+class TestAuditReviewProfile:
+    """Verify reviewer_audit-review.md grades test design quality, not execution results."""
+
+    def test_audit_review_profile_exists(self) -> None:
+        """Audit-review profile template file exists."""
+        template = _template_path("reviewer_audit-review.md")
+        assert template.exists(), f"reviewer_audit-review.md not found at {template}"
+
+    def test_audit_review_grades_design_not_execution(self) -> None:
+        """Audit-review profile instructs grading design quality, not pass/fail status."""
+        template = _template_path("reviewer_audit-review.md")
+        content = template.read_text(encoding="utf-8")
+        assert "design quality" in content.lower(), (
+            "Audit-review profile should instruct grading 'design quality'"
+        )
+        assert "not execution results" in content.lower() or "not pass/fail status" in content.lower(), (
+            "Audit-review profile should explicitly state not to grade execution results"
+        )
+
+    def test_audit_review_has_anti_pattern_guidance(self) -> None:
+        """Audit-review profile contains anti-pattern guidance against penalising failures."""
+        template = _template_path("reviewer_audit-review.md")
+        content = template.read_text(encoding="utf-8")
+        assert "anti-pattern" in content.lower(), (
+            "Audit-review profile should contain anti-pattern guidance"
+        )
+        assert "INCORRECT" in content, (
+            "Audit-review profile should show INCORRECT example of the anti-pattern"
+        )
+        assert "CORRECT" in content, (
+            "Audit-review profile should show CORRECT example"
+        )
+
+    def test_audit_review_pass_verdict_ignores_execution_status(self) -> None:
+        """PASS verdict definition mentions 'regardless of pass/fail status'."""
+        template = _template_path("reviewer_audit-review.md")
+        content = template.read_text(encoding="utf-8")
+        assert "regardless of" in content.lower(), (
+            "PASS verdict should state it applies regardless of current pass/fail status"
+        )
+
+    def test_audit_review_weak_means_design_flaws(self) -> None:
+        """WEAK verdict definition focuses on actual design flaws, not execution failures."""
+        template = _template_path("reviewer_audit-review.md")
+        content = template.read_text(encoding="utf-8")
+        assert "design flaws" in content.lower(), (
+            "WEAK verdict should be defined as actual design flaws"
+        )
+
+    def test_audit_review_has_upstream_dependency_guidance(self) -> None:
+        """Audit-review profile addresses multi-spec upstream dependency scenario."""
+        template = _template_path("reviewer_audit-review.md")
+        content = template.read_text(encoding="utf-8")
+        assert "upstream" in content.lower() or "other specs" in content.lower(), (
+            "Audit-review profile should address tests failing due to unimplemented upstream specs"
+        )
+
+    def test_audit_review_has_json_output_format(self) -> None:
+        """Audit-review profile specifies JSON output with required fields."""
+        template = _template_path("reviewer_audit-review.md")
+        content = template.read_text(encoding="utf-8")
+        assert '"audit"' in content
+        assert '"ts_entry"' in content
+        assert '"verdict"' in content
+        assert '"overall_verdict"' in content
+
+    def test_audit_review_identity_does_not_require_passing(self) -> None:
+        """Identity section should not require tests to be 'passing'."""
+        template = _template_path("reviewer_audit-review.md")
+        content = template.read_text(encoding="utf-8")
+        # Extract just the Identity section (up to ## Rules)
+        identity_end = content.find("## Rules")
+        identity_section = content[:identity_end] if identity_end > 0 else content[:200]
+        assert "passing" not in identity_section.lower(), (
+            "Identity section should not require 'passing' tests — "
+            "the reviewer grades design quality, not execution results"
+        )
+
+
 class TestFixCoderProfileRetained:
     """Verify coder_fix.md is available as a mode-specific profile."""
 


### PR DESCRIPTION
## Summary

- Updated `reviewer_audit-review.md` profile to grade test **design quality** instead of test execution results
- Well-designed tests that fail due to unimplemented upstream specs are now `PASS`, not `WEAK`
- Added anti-pattern section with INCORRECT/CORRECT examples to prevent the conflation from recurring
- Added 8 new tests verifying the template content changes

Closes #568

## Changes

| File | Change |
|------|--------|
| `agent_fox/_templates/profiles/reviewer_audit-review.md` | Rewrote identity, focus areas, and verdict definitions; added anti-pattern and upstream dependency guidance |
| `tests/unit/templates/test_reviewer_template.py` | Added `TestAuditReviewProfile` class (8 tests) |
| `docs/memory.md` | Added session entry |

## Tests

- `TestAuditReviewProfile` (8 tests): design-quality grading, anti-pattern guidance, upstream deps, verdict definitions, JSON format, identity section

## Verification

- All existing tests pass: ✅ (4672 passed)
- New tests pass: ✅ (8 new)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*