### PR TITLE
feat(workspace): cleanup stale worktrees at startup (fixes #629)

### DIFF
--- a/packages/agentfox/agentfox/engine/engine.py
+++ b/packages/agentfox/agentfox/engine/engine.py
@@ -532,6 +532,7 @@ class Orchestrator:
                 payload={
                     "push_available": preflight.push_available,
                     "worktrees_pruned": preflight.worktrees_pruned,
+                    "stale_worktrees_removed": preflight.stale_worktrees_removed,
                     "stale_locks": preflight.stale_locks_found,
                     "issues": preflight.issues_found,
                 },

--- a/packages/agentfox/agentfox/workspace/health.py
+++ b/packages/agentfox/agentfox/workspace/health.py
@@ -11,6 +11,7 @@ Requirements: 118-REQ-1.1, 118-REQ-1.3, 118-REQ-1.E1, 118-REQ-1.E2,
 from __future__ import annotations
 
 import logging
+import shutil
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -236,6 +237,114 @@ class WorkspacePreflightResult:
     issues_found: list[str] = field(default_factory=list)
     worktrees_pruned: bool = False
     stale_locks_found: list[str] = field(default_factory=list)
+    stale_worktrees_removed: int = 0
+
+
+async def cleanup_stale_worktrees(repo_root: Path) -> int:
+    """Remove all worktree directories under ``.agent-fox/worktrees/``.
+
+    At orchestrator startup there are no active sessions, so every directory
+    under the worktrees root is stale — left over from a prior interrupted
+    run.  Each worktree is removed via ``git worktree remove --force``,
+    falling back to ``shutil.rmtree`` if the git command fails.  Empty
+    parent directories are cleaned up afterward.
+
+    Best-effort: never raises.  Returns the count of worktrees removed.
+
+    Issue: #629
+    """
+    worktrees_root = repo_root / ".agent-fox" / "worktrees"
+    if not worktrees_root.is_dir():
+        return 0
+
+    # Collect worktree paths registered in git that live under our root.
+    registered: set[str] = set()
+    try:
+        _rc, stdout, _stderr = await run_git(
+            ["worktree", "list", "--porcelain"],
+            cwd=repo_root,
+            check=False,
+        )
+        for line in stdout.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("worktree "):
+                wt_path = stripped[len("worktree ") :]
+                try:
+                    if Path(wt_path).is_relative_to(worktrees_root):
+                        registered.add(wt_path)
+                except (ValueError, TypeError):
+                    pass
+    except Exception:
+        logger.debug("Could not list worktrees during stale cleanup", exc_info=True)
+
+    removed = 0
+
+    # Phase 1: remove registered worktrees via git worktree remove --force
+    for wt_path_str in registered:
+        wt_path = Path(wt_path_str)
+        if not wt_path.exists():
+            continue
+        try:
+            rc, _, _ = await run_git(
+                ["worktree", "remove", "--force", str(wt_path)],
+                cwd=repo_root,
+                check=False,
+            )
+            if rc != 0 and wt_path.exists():
+                shutil.rmtree(wt_path, ignore_errors=True)
+            if not wt_path.exists():
+                removed += 1
+                logger.info("Removed stale worktree: %s", wt_path)
+        except Exception:
+            logger.debug("Failed to remove registered worktree %s", wt_path, exc_info=True)
+
+    # Phase 2: remove any remaining directories (orphans not in git registry)
+    try:
+        for child in _walk_leaf_dirs(worktrees_root):
+            if child.is_dir():
+                try:
+                    shutil.rmtree(child, ignore_errors=True)
+                    if not child.exists():
+                        removed += 1
+                        logger.info("Removed orphan worktree directory: %s", child)
+                except Exception:
+                    logger.debug("Failed to remove orphan directory %s", child, exc_info=True)
+    except Exception:
+        logger.debug("Failed to scan for orphan worktree directories", exc_info=True)
+
+    # Phase 3: clean up empty ancestor directories
+    try:
+        for child in sorted(worktrees_root.rglob("*"), reverse=True):
+            if child.is_dir():
+                try:
+                    child.rmdir()
+                except OSError:
+                    pass
+    except Exception:
+        pass
+
+    # Phase 4: prune the git worktree registry
+    try:
+        await run_git(["worktree", "prune"], cwd=repo_root, check=False)
+    except Exception:
+        logger.debug("git worktree prune failed during stale cleanup", exc_info=True)
+
+    if removed:
+        logger.info("Cleaned up %d stale worktree(s) from prior run", removed)
+
+    return removed
+
+
+def _walk_leaf_dirs(root: Path) -> list[Path]:
+    """Return leaf directories under *root* (dirs with no subdirectories)."""
+    leaves: list[Path] = []
+    try:
+        for child in root.rglob("*"):
+            if child.is_dir() and not any(c.is_dir() for c in child.iterdir()):
+                leaves.append(child)
+    except Exception:
+        pass
+    return leaves
 
 
 async def run_preflight_workspace_check(repo_root: Path) -> WorkspacePreflightResult:
@@ -250,7 +359,14 @@ async def run_preflight_workspace_check(repo_root: Path) -> WorkspacePreflightRe
     """
     result = WorkspacePreflightResult()
 
-    # 1. Prune stale worktree entries
+    # 1a. Remove stale worktree directories from prior interrupted runs (#629)
+    try:
+        removed = await cleanup_stale_worktrees(repo_root)
+        result.stale_worktrees_removed = removed
+    except Exception:
+        logger.warning("Run pre-flight: stale worktree cleanup raised exception", exc_info=True)
+
+    # 1b. Prune stale worktree entries
     try:
         rc, _stdout, stderr = await run_git(
             ["worktree", "prune"],

--- a/packages/agentfox/tests/unit/workspace/test_run_preflight.py
+++ b/packages/agentfox/tests/unit/workspace/test_run_preflight.py
@@ -4,6 +4,7 @@ Verifies that run_preflight_workspace_check correctly:
 - Prunes stale worktree entries
 - Detects stale lock files
 - Tests git credential availability
+- Cleans up stale worktree directories (issue #629)
 - Returns structured results
 """
 
@@ -15,6 +16,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from agentfox.workspace.health import (
     WorkspacePreflightResult,
+    cleanup_stale_worktrees,
     run_preflight_workspace_check,
 )
 
@@ -125,3 +127,149 @@ class TestRunPreflightWorkspaceCheck:
             result = await run_preflight_workspace_check(tmp_path)
 
         assert isinstance(result, WorkspacePreflightResult)
+
+
+# ---------------------------------------------------------------------------
+# Stale worktree cleanup (issue #629)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupStaleWorktrees:
+    """cleanup_stale_worktrees removes leftover worktree directories at startup."""
+
+    @pytest.mark.asyncio
+    async def test_no_worktrees_dir_is_noop(self, tmp_path: Path) -> None:
+        """No .agent-fox/worktrees/ directory → 0 removed, no errors."""
+        count = await cleanup_stale_worktrees(tmp_path)
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_worktrees_dir_is_noop(self, tmp_path: Path) -> None:
+        """Empty .agent-fox/worktrees/ → 0 removed."""
+        (tmp_path / ".agent-fox" / "worktrees").mkdir(parents=True)
+        count = await cleanup_stale_worktrees(tmp_path)
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_removes_stale_worktree_directories(self, tmp_path: Path) -> None:
+        """Stale worktree directories are removed via git worktree remove --force."""
+        worktrees_root = tmp_path / ".agent-fox" / "worktrees"
+        wt1 = worktrees_root / "spec_a" / "1"
+        wt2 = worktrees_root / "spec_b" / "2"
+        wt1.mkdir(parents=True)
+        wt2.mkdir(parents=True)
+        (wt1 / "some_file.py").touch()
+        (wt2 / "other_file.py").touch()
+
+        git_calls: list[list[str]] = []
+
+        async def mock_git(args, cwd, check=True, timeout=None):
+            git_calls.append(args)
+            if args[:2] == ["worktree", "list"]:
+                return (
+                    0,
+                    f"worktree {wt1}\nbranch refs/heads/feature/spec_a/1\n\n"
+                    f"worktree {wt2}\nbranch refs/heads/feature/spec_b/2\n\n",
+                    "",
+                )
+            return (0, "", "")
+
+        with patch("agentfox.workspace.health.run_git", side_effect=mock_git):
+            count = await cleanup_stale_worktrees(tmp_path)
+
+        assert count == 2
+        remove_calls = [c for c in git_calls if c[:2] == ["worktree", "remove"]]
+        assert len(remove_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_fallback_rmtree_when_git_remove_fails(self, tmp_path: Path) -> None:
+        """When git worktree remove fails, fall back to shutil.rmtree."""
+        worktrees_root = tmp_path / ".agent-fox" / "worktrees"
+        wt = worktrees_root / "spec_x" / "1"
+        wt.mkdir(parents=True)
+        (wt / "file.py").touch()
+
+        async def mock_git(args, cwd, check=True, timeout=None):
+            if args[:2] == ["worktree", "list"]:
+                return (0, "", "")
+            if args[:2] == ["worktree", "remove"]:
+                return (1, "", "error: failed")
+            return (0, "", "")
+
+        with patch("agentfox.workspace.health.run_git", side_effect=mock_git):
+            count = await cleanup_stale_worktrees(tmp_path)
+
+        assert count == 1
+        assert not wt.exists()
+
+    @pytest.mark.asyncio
+    async def test_cleans_empty_parent_dirs(self, tmp_path: Path) -> None:
+        """After removal, empty parent dirs like spec_name/ are cleaned up."""
+        worktrees_root = tmp_path / ".agent-fox" / "worktrees"
+        wt = worktrees_root / "spec_y" / "3"
+        wt.mkdir(parents=True)
+        (wt / "code.py").touch()
+
+        async def mock_git(args, cwd, check=True, timeout=None):
+            if args[:2] == ["worktree", "list"]:
+                return (0, "", "")
+            return (0, "", "")
+
+        with patch("agentfox.workspace.health.run_git", side_effect=mock_git):
+            count = await cleanup_stale_worktrees(tmp_path)
+
+        assert count == 1
+        assert not (worktrees_root / "spec_y").exists()
+
+    @pytest.mark.asyncio
+    async def test_never_raises_on_git_failure(self, tmp_path: Path) -> None:
+        """cleanup_stale_worktrees never raises even when git commands fail."""
+        worktrees_root = tmp_path / ".agent-fox" / "worktrees"
+        wt = worktrees_root / "spec_z" / "1"
+        wt.mkdir(parents=True)
+
+        with patch("agentfox.workspace.health.run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = Exception("total failure")
+            count = await cleanup_stale_worktrees(tmp_path)
+
+        assert isinstance(count, int)
+
+    @pytest.mark.asyncio
+    async def test_four_level_paths_cleaned(self, tmp_path: Path) -> None:
+        """4-level worktree paths (spec/group/role/mode) are also cleaned."""
+        worktrees_root = tmp_path / ".agent-fox" / "worktrees"
+        wt = worktrees_root / "spec_r" / "2" / "reviewer" / "audit-review"
+        wt.mkdir(parents=True)
+        (wt / "test.py").touch()
+
+        async def mock_git(args, cwd, check=True, timeout=None):
+            if args[:2] == ["worktree", "list"]:
+                return (0, f"worktree {wt}\nbranch refs/heads/feature/spec_r/2/reviewer/audit-review\n\n", "")
+            return (0, "", "")
+
+        with patch("agentfox.workspace.health.run_git", side_effect=mock_git):
+            count = await cleanup_stale_worktrees(tmp_path)
+
+        assert count == 1
+        assert not wt.exists()
+
+    @pytest.mark.asyncio
+    async def test_preflight_calls_cleanup(self, tmp_path: Path) -> None:
+        """run_preflight_workspace_check invokes cleanup_stale_worktrees."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        worktrees_root = tmp_path / ".agent-fox" / "worktrees"
+        wt = worktrees_root / "spec_p" / "1"
+        wt.mkdir(parents=True)
+        (wt / "f.py").touch()
+
+        async def mock_git(args, cwd, check=True, timeout=None):
+            if args[:2] == ["worktree", "list"]:
+                return (0, "", "")
+            return (0, "", "")
+
+        with patch("agentfox.workspace.health.run_git", side_effect=mock_git):
+            result = await run_preflight_workspace_check(tmp_path)
+
+        assert result.stale_worktrees_removed >= 1
+        assert not wt.exists()


### PR DESCRIPTION
## Summary

- Add `cleanup_stale_worktrees()` to `workspace/health.py` that removes all worktree directories under `.agent-fox/worktrees/` at orchestrator startup
- At startup there are no active sessions, so all worktrees are stale from a prior interrupted run
- Uses `git worktree remove --force` with `shutil.rmtree` fallback, cleans up empty parent dirs, prunes git registry
- Wired into `run_preflight_workspace_check()` for automatic execution before every run

Closes #629

## Changes

| File | Change |
|------|--------|
| `packages/agentfox/agentfox/workspace/health.py` | Added `cleanup_stale_worktrees()`, `_walk_leaf_dirs()`, `stale_worktrees_removed` field |
| `packages/agentfox/agentfox/engine/engine.py` | Added `stale_worktrees_removed` to preflight audit payload |
| `packages/agentfox/tests/unit/workspace/test_run_preflight.py` | 8 new tests for stale worktree cleanup |

## Tests

- `TestCleanupStaleWorktrees`: 8 tests covering no-op, removal via git, fallback rmtree, empty parent cleanup, error resilience, 4-level paths, and preflight integration
- All 283 workspace/preflight tests pass

## Verification

- All existing tests pass: ✅
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*