### PR TITLE
fix(engine): cross-check and remove orphaned worktree dirs (fixes #618)

### DIFF
--- a/packages/agentfox/agentfox/engine/barrier.py
+++ b/packages/agentfox/agentfox/engine/barrier.py
@@ -14,6 +14,8 @@ Requirements: 51-REQ-2.1, 51-REQ-2.2, 51-REQ-2.3, 51-REQ-2.E1,
 from __future__ import annotations
 
 import logging
+import re
+import shutil
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -24,12 +26,21 @@ from agentfox.workspace.merge_lock import MergeLock
 
 logger = logging.getLogger(__name__)
 
+_SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
 
-def verify_worktrees(repo_root: Path) -> list[Path]:
+
+async def verify_worktrees(repo_root: Path) -> list[Path]:
     """Scan .agent-fox/worktrees/ for orphaned directories.
 
-    Returns list of orphaned paths (empty if none found).
-    Logs a warning per orphaned path.
+    Cross-checks ``git worktree list --porcelain`` to distinguish active
+    registered worktrees from truly orphaned directories (AC-1, issue #618).
+    Directories whose names do not match ``[a-zA-Z0-9_-]+`` (e.g. dotfiles
+    like ``.claude``) are logged but skipped for safety (AC-3).
+    Confirmed orphans matching the safe pattern are removed from disk (AC-2).
+    Removal errors are caught and logged as warnings (AC-5).
+
+    Returns the list of orphaned paths (including those that could not be
+    removed) for audit purposes.
 
     Requirements: 51-REQ-2.1, 51-REQ-2.2, 51-REQ-2.3, 51-REQ-2.E1
     """
@@ -39,14 +50,47 @@ def verify_worktrees(repo_root: Path) -> list[Path]:
     if not worktrees_dir.exists():
         return []
 
+    # AC-1: query git for registered worktree paths
+    registered: set[str] = set()
+    try:
+        _rc, stdout, _stderr = await run_git(
+            ["worktree", "list", "--porcelain"],
+            cwd=repo_root,
+            check=False,
+        )
+        for line in stdout.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("worktree "):
+                registered.add(stripped[len("worktree ") :])
+    except Exception:
+        logger.warning("Could not query git worktree list during verification", exc_info=True)
+
     orphans: list[Path] = []
     for child in worktrees_dir.iterdir():
-        if child.is_dir():
-            orphans.append(child)
+        if not child.is_dir():
+            continue
+        # AC-1: skip directories that are registered worktrees (or parents thereof)
+        child_str = str(child)
+        if any(r == child_str or r.startswith(child_str + "/") for r in registered):
+            continue
+        orphans.append(child)
 
-    # 51-REQ-2.2: log warning for each orphaned path
+    # 51-REQ-2.2: log warning and remediate each orphan
     for orphan in orphans:
-        logger.warning("Orphaned worktree directory found: %s", orphan)
+        name = orphan.name
+        # AC-3: skip directories whose names don't match the safe pattern
+        if not _SAFE_NAME_RE.match(name):
+            logger.warning(
+                "Orphaned worktree directory skipped for safety (suspicious name): %s",
+                orphan,
+            )
+            continue
+        logger.warning("Orphaned worktree directory found, removing: %s", orphan)
+        # AC-2: remove confirmed orphan; AC-5: catch errors
+        try:
+            shutil.rmtree(orphan)
+        except OSError:
+            logger.warning("Failed to remove orphaned worktree directory: %s", orphan, exc_info=True)
 
     return orphans
 
@@ -170,7 +214,7 @@ async def run_sync_barrier_sequence(
     # 51-REQ-2.1: Verify worktrees for orphans
     orphaned_worktrees: list[str] = []
     try:
-        orphans = verify_worktrees(repo_root)
+        orphans = await verify_worktrees(repo_root)
         orphaned_worktrees = [str(p) for p in orphans]
     except Exception:
         logger.warning("Worktree verification failed", exc_info=True)

--- a/packages/agentfox/tests/property/engine/test_barrier_props.py
+++ b/packages/agentfox/tests/property/engine/test_barrier_props.py
@@ -105,7 +105,11 @@ class TestWorktreeVerificationNeverRaises:
                 for i in range(subdir_count):
                     (wt_dir / f"spec_{i}" / "1").mkdir(parents=True)
 
-            result = verify_worktrees(repo_root)
+            async def _mock_git(args, cwd, check=True, **kwargs):
+                return (0, "", "")
+
+            with patch("agentfox.engine.barrier.run_git", side_effect=_mock_git):
+                result = asyncio.get_event_loop().run_until_complete(verify_worktrees(repo_root))
             assert isinstance(result, list)
 
 

--- a/packages/agentfox/tests/unit/engine/test_barrier.py
+++ b/packages/agentfox/tests/unit/engine/test_barrier.py
@@ -22,6 +22,13 @@ from agentfox.engine.barrier import (
 from agentfox.engine.state import ExecutionState
 
 
+def _mock_git_no_worktrees(args, cwd, check=True, **kwargs):
+    """Mock run_git returning empty worktree list."""
+    if args[:2] == ["worktree", "list"]:
+        return (0, "", "")
+    return (0, "", "")
+
+
 class TestVerifyWorktreesOrphansFound:
     """TS-51-5: Worktree verification finds orphans.
 
@@ -30,26 +37,32 @@ class TestVerifyWorktreesOrphansFound:
     Requirements: 51-REQ-2.1, 51-REQ-2.2
     """
 
-    def test_finds_orphaned_worktree_dirs(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_finds_orphaned_worktree_dirs(self, tmp_path: Path) -> None:
         """Orphaned worktree subdirectories are detected."""
         wt_dir = tmp_path / ".agent-fox" / "worktrees"
         (wt_dir / "spec_a" / "1").mkdir(parents=True)
         (wt_dir / "spec_b" / "2").mkdir(parents=True)
 
-        result = verify_worktrees(tmp_path)
+        with patch("agentfox.engine.barrier.run_git", new_callable=AsyncMock, side_effect=_mock_git_no_worktrees):
+            result = await verify_worktrees(tmp_path)
         assert len(result) == 2
         names = {p.name for p in result}
         assert "spec_a" in names
         assert "spec_b" in names
 
-    def test_logs_warning_for_orphans(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    @pytest.mark.asyncio
+    async def test_logs_warning_for_orphans(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         """WARNING log emitted listing orphaned paths."""
         wt_dir = tmp_path / ".agent-fox" / "worktrees"
         (wt_dir / "spec_a" / "1").mkdir(parents=True)
         (wt_dir / "spec_b" / "2").mkdir(parents=True)
 
-        with caplog.at_level(logging.WARNING, logger="agentfox.engine.barrier"):
-            verify_worktrees(tmp_path)
+        with (
+            caplog.at_level(logging.WARNING, logger="agentfox.engine.barrier"),
+            patch("agentfox.engine.barrier.run_git", new_callable=AsyncMock, side_effect=_mock_git_no_worktrees),
+        ):
+            await verify_worktrees(tmp_path)
 
         assert "spec_a" in caplog.text
         assert "spec_b" in caplog.text
@@ -61,21 +74,27 @@ class TestVerifyWorktreesNoOrphans:
     Requirements: 51-REQ-2.3
     """
 
-    def test_returns_empty_list_when_no_orphans(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_no_orphans(self, tmp_path: Path) -> None:
         """Empty worktrees directory returns empty list."""
         wt_dir = tmp_path / ".agent-fox" / "worktrees"
         wt_dir.mkdir(parents=True)
 
-        result = verify_worktrees(tmp_path)
+        with patch("agentfox.engine.barrier.run_git", new_callable=AsyncMock, side_effect=_mock_git_no_worktrees):
+            result = await verify_worktrees(tmp_path)
         assert result == []
 
-    def test_no_warning_when_no_orphans(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    @pytest.mark.asyncio
+    async def test_no_warning_when_no_orphans(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         """No warnings logged when no orphans exist."""
         wt_dir = tmp_path / ".agent-fox" / "worktrees"
         wt_dir.mkdir(parents=True)
 
-        with caplog.at_level(logging.WARNING, logger="agentfox.engine.barrier"):
-            verify_worktrees(tmp_path)
+        with (
+            caplog.at_level(logging.WARNING, logger="agentfox.engine.barrier"),
+            patch("agentfox.engine.barrier.run_git", new_callable=AsyncMock, side_effect=_mock_git_no_worktrees),
+        ):
+            await verify_worktrees(tmp_path)
 
         assert caplog.text == ""
 
@@ -86,10 +105,104 @@ class TestVerifyWorktreesDirMissing:
     Requirements: 51-REQ-2.E1
     """
 
-    def test_returns_empty_when_dir_missing(self, tmp_path: Path) -> None:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_dir_missing(self, tmp_path: Path) -> None:
         """Missing .agent-fox/worktrees/ returns empty list, no exception."""
-        result = verify_worktrees(tmp_path)
+        result = await verify_worktrees(tmp_path)
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #618: orphaned worktree cleanup acceptance criteria
+# ---------------------------------------------------------------------------
+
+
+class TestAC1CrossCheckGitWorktreeList:
+    """AC-1: verify_worktrees cross-checks git worktree list."""
+
+    @pytest.mark.asyncio
+    async def test_registered_worktree_excluded_from_orphans(self, tmp_path: Path) -> None:
+        """A directory registered in git worktree list is NOT an orphan."""
+        wt_dir = tmp_path / ".agent-fox" / "worktrees"
+        active = wt_dir / "spec_a" / "1"
+        orphan = wt_dir / "spec_b" / "2"
+        active.mkdir(parents=True)
+        orphan.mkdir(parents=True)
+
+        async def mock_git(args, cwd, check=True, **kwargs):
+            if args[:2] == ["worktree", "list"]:
+                return (0, f"worktree {active}\nbranch refs/heads/feature/spec_a/1\n\n", "")
+            return (0, "", "")
+
+        with patch("agentfox.engine.barrier.run_git", side_effect=mock_git):
+            result = await verify_worktrees(tmp_path)
+
+        names = {p.name for p in result}
+        assert "spec_b" in names
+        assert "spec_a" not in names
+
+
+class TestAC2RemoveConfirmedOrphans:
+    """AC-2: verify_worktrees removes confirmed orphans."""
+
+    @pytest.mark.asyncio
+    async def test_orphan_removed_from_disk(self, tmp_path: Path) -> None:
+        """After verify_worktrees(), the orphaned directory no longer exists."""
+        wt_dir = tmp_path / ".agent-fox" / "worktrees"
+        orphan = wt_dir / "fix-issue-605"
+        orphan.mkdir(parents=True)
+        (orphan / "file.py").touch()
+
+        with patch("agentfox.engine.barrier.run_git", new_callable=AsyncMock, side_effect=_mock_git_no_worktrees):
+            result = await verify_worktrees(tmp_path)
+
+        assert len(result) == 1
+        assert not orphan.exists()
+
+
+class TestAC3NamingPatternSafetyCheck:
+    """AC-3: verify_worktrees applies naming-pattern safety check."""
+
+    @pytest.mark.asyncio
+    async def test_dotfile_skipped_safe_name_removed(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """`.claude` is skipped for safety; `fix-issue-605` is removed."""
+        wt_dir = tmp_path / ".agent-fox" / "worktrees"
+        dotfile = wt_dir / ".claude"
+        safe = wt_dir / "fix-issue-605"
+        dotfile.mkdir(parents=True)
+        safe.mkdir(parents=True)
+
+        with (
+            caplog.at_level(logging.WARNING, logger="agentfox.engine.barrier"),
+            patch("agentfox.engine.barrier.run_git", new_callable=AsyncMock, side_effect=_mock_git_no_worktrees),
+        ):
+            result = await verify_worktrees(tmp_path)
+
+        assert len(result) == 2
+        assert not safe.exists(), "fix-issue-605 should be removed"
+        assert dotfile.exists(), ".claude should NOT be removed"
+        assert "skipped for safety" in caplog.text
+
+
+class TestAC5RemovalErrorsCaught:
+    """AC-5: removal errors are caught and logged, never propagated."""
+
+    @pytest.mark.asyncio
+    async def test_permission_error_caught(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """PermissionError on removal is caught; function does not raise."""
+        wt_dir = tmp_path / ".agent-fox" / "worktrees"
+        orphan = wt_dir / "fix-issue-609"
+        orphan.mkdir(parents=True)
+
+        with (
+            caplog.at_level(logging.WARNING, logger="agentfox.engine.barrier"),
+            patch("agentfox.engine.barrier.run_git", new_callable=AsyncMock, side_effect=_mock_git_no_worktrees),
+            patch("agentfox.engine.barrier.shutil.rmtree", side_effect=PermissionError("denied")),
+        ):
+            result = await verify_worktrees(tmp_path)
+
+        assert len(result) == 1
+        assert "fix-issue-609" in caplog.text
 
 
 class TestSyncDevelopBidirectionalSuccess:
@@ -305,7 +418,7 @@ class TestCompactionCalledDuringBarrier:
     async def test_barrier_completes_with_db_conn(self, tmp_path: Path) -> None:
         """Barrier completes with knowledge_db_conn (no compaction)."""
         with (
-            patch("agentfox.engine.barrier.verify_worktrees", return_value=[]),
+            patch("agentfox.engine.barrier.verify_worktrees", new_callable=AsyncMock, return_value=[]),
             patch(
                 "agentfox.engine.barrier.sync_integration_bidirectional",
                 new_callable=AsyncMock,
@@ -329,7 +442,7 @@ class TestCompactionCalledDuringBarrier:
     async def test_barrier_completes_without_db_conn(self, tmp_path: Path) -> None:
         """Barrier completes when knowledge_db_conn is None."""
         with (
-            patch("agentfox.engine.barrier.verify_worktrees", return_value=[]),
+            patch("agentfox.engine.barrier.verify_worktrees", new_callable=AsyncMock, return_value=[]),
             patch(
                 "agentfox.engine.barrier.sync_integration_bidirectional",
                 new_callable=AsyncMock,
@@ -353,7 +466,7 @@ class TestCompactionCalledDuringBarrier:
     async def test_barrier_completes_without_knowledge_steps(self, tmp_path: Path) -> None:
         """Barrier completes without compaction, rendering, or other knowledge steps."""
         with (
-            patch("agentfox.engine.barrier.verify_worktrees", return_value=[]),
+            patch("agentfox.engine.barrier.verify_worktrees", new_callable=AsyncMock, return_value=[]),
             patch(
                 "agentfox.engine.barrier.sync_integration_bidirectional",
                 new_callable=AsyncMock,
@@ -449,7 +562,7 @@ class TestBarrierProgressPrint:
             updated_at="2026-04-01T00:00:01Z",
         )
         with (
-            patch("agentfox.engine.barrier.verify_worktrees", return_value=[]),
+            patch("agentfox.engine.barrier.verify_worktrees", new_callable=AsyncMock, return_value=[]),
             patch(
                 "agentfox.engine.barrier.sync_integration_bidirectional",
                 new_callable=AsyncMock,
@@ -474,7 +587,7 @@ class TestBarrierProgressPrint:
             updated_at="2026-04-01T00:00:01Z",
         )
         with (
-            patch("agentfox.engine.barrier.verify_worktrees", return_value=[]),
+            patch("agentfox.engine.barrier.verify_worktrees", new_callable=AsyncMock, return_value=[]),
             patch(
                 "agentfox.engine.barrier.sync_integration_bidirectional",
                 new_callable=AsyncMock,
@@ -506,7 +619,7 @@ class TestBarrierProgressPrint:
             updated_at="2026-04-01T00:00:01Z",
         )
         with (
-            patch("agentfox.engine.barrier.verify_worktrees", return_value=[]),
+            patch("agentfox.engine.barrier.verify_worktrees", new_callable=AsyncMock, return_value=[]),
             patch(
                 "agentfox.engine.barrier.sync_integration_bidirectional",
                 new_callable=AsyncMock,
@@ -530,7 +643,7 @@ class TestBarrierProgressPrint:
 
         state = _make_barrier_state()
         with (
-            patch("agentfox.engine.barrier.verify_worktrees", return_value=[]),
+            patch("agentfox.engine.barrier.verify_worktrees", new_callable=AsyncMock, return_value=[]),
             patch(
                 "agentfox.engine.barrier.sync_integration_bidirectional",
                 side_effect=_mock_sync,

--- a/packages/agentfox/tests/unit/engine/test_config_reload.py
+++ b/packages/agentfox/tests/unit/engine/test_config_reload.py
@@ -84,7 +84,7 @@ class TestReloadTriggeredAtBarrier:
         reload_fn = MagicMock()
 
         with (
-            patch("agentfox.engine.barrier.verify_worktrees", return_value=[]),
+            patch("agentfox.engine.barrier.verify_worktrees", new_callable=AsyncMock, return_value=[]),
             patch(
                 "agentfox.engine.barrier.sync_integration_bidirectional",
                 new_callable=AsyncMock,

--- a/packages/agentfox/tests/unit/engine/test_orchestrator.py
+++ b/packages/agentfox/tests/unit/engine/test_orchestrator.py
@@ -869,7 +869,7 @@ class TestSyncBarrierTriggering:
 
         with (
             patch("agentfox.engine.barrier.sync_integration_bidirectional", new_callable=AsyncMock),
-            patch("agentfox.engine.barrier.verify_worktrees", return_value=[]),
+            patch("agentfox.engine.barrier.verify_worktrees", new_callable=AsyncMock, return_value=[]),
         ):
             orchestrator = Orchestrator(
                 config=config,
@@ -907,7 +907,7 @@ class TestSyncBarrierTriggering:
 
         with (
             patch("agentfox.engine.barrier.sync_integration_bidirectional", new_callable=AsyncMock),
-            patch("agentfox.engine.barrier.verify_worktrees", return_value=[]),
+            patch("agentfox.engine.barrier.verify_worktrees", new_callable=AsyncMock, return_value=[]),
         ):
             orchestrator = Orchestrator(
                 config=config,
@@ -984,7 +984,7 @@ class TestSyncBarrierTriggering:
 
         with (
             patch("agentfox.engine.barrier.sync_integration_bidirectional", new_callable=AsyncMock),
-            patch("agentfox.engine.barrier.verify_worktrees", return_value=[]),
+            patch("agentfox.engine.barrier.verify_worktrees", new_callable=AsyncMock, return_value=[]),
         ):
             orchestrator = Orchestrator(
                 config=config,

--- a/packages/agentfox/tests/unit/knowledge/test_decoupling.py
+++ b/packages/agentfox/tests/unit/knowledge/test_decoupling.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from agentfox.knowledge.fox_provider import KnowledgeProvider, NoOpKnowledgeProvider
@@ -184,6 +184,7 @@ class TestBarrierRetainedSteps:
         with (
             patch(
                 "agentfox.engine.barrier.verify_worktrees",
+                new_callable=AsyncMock,
                 return_value=[],
             ) as mock_verify,
             patch(


### PR DESCRIPTION
## Summary

- Rewrote `verify_worktrees()` as async with `git worktree list --porcelain` cross-check to distinguish active worktrees from orphans (AC-1)
- Applies `[a-zA-Z0-9_-]+` naming-pattern safety check — skips dotfiles like `.claude`, `.hypothesis` (AC-3)
- Removes confirmed orphans via `shutil.rmtree` after logging (AC-2)
- Catches removal errors as non-fatal warnings (AC-5)
- AC-4 already satisfied by #629's `cleanup_stale_worktrees()` in health.py

Closes #618

## Changes

| File | Change |
|------|--------|
| `packages/agentfox/agentfox/engine/barrier.py` | Async `verify_worktrees()` with git cross-check, naming safety, removal |
| `packages/agentfox/tests/unit/engine/test_barrier.py` | Updated + 4 new AC tests |
| `packages/agentfox/tests/unit/knowledge/test_decoupling.py` | AsyncMock for verify_worktrees |
| `packages/agentfox/tests/unit/engine/test_orchestrator.py` | AsyncMock for verify_worktrees |
| `packages/agentfox/tests/unit/engine/test_config_reload.py` | AsyncMock for verify_worktrees |
| `packages/agentfox/tests/property/engine/test_barrier_props.py` | Async property test |

## Tests

- AC-1: registered worktree excluded from orphans
- AC-2: orphan directory removed from disk
- AC-3: dotfiles skipped, safe names removed
- AC-5: PermissionError caught, never propagated

## Verification

- All existing tests pass: ✅
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*