### PR TITLE
fix(afspec): coerce Subtask.details string to list before validation (fixes #658)

### DIFF
--- a/packages/afspec/afspec/models.py
+++ b/packages/afspec/afspec/models.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic import BaseModel, Field, PrivateAttr, field_validator
 
 from afspec.exceptions import LifecycleError
 
@@ -339,6 +339,13 @@ class Subtask(BaseModel):
     requirement_refs: list[str] = Field(default_factory=list)
     state: SubtaskState = SubtaskState.PENDING
     optional: bool = False
+
+    @field_validator("details", mode="before")
+    @classmethod
+    def _coerce_details_to_list(cls, v: Any) -> list[str]:
+        if isinstance(v, str):
+            return [v]
+        return v
 
     def transition_to(self, target: SubtaskState) -> Subtask:
         """Transition to a new state.

--- a/packages/afspec/tests/test_models.py
+++ b/packages/afspec/tests/test_models.py
@@ -441,3 +441,52 @@ def test_property_constructor_completeness(spec_id: str, spec_name: str) -> None
     assert op.ears_pattern == EARSPattern.OPTIONAL
     assert op.feature == "export"
     assert op.error_condition is None
+
+
+# ---------------------------------------------------------------------------
+# Subtask.details string coercion (fixes #658)
+# ---------------------------------------------------------------------------
+
+
+class TestSubtaskDetailsCoercion:
+    """Subtask.details coerces a bare string to a single-element list."""
+
+    def test_string_coerced_to_list(self) -> None:
+        sub = Subtask(id="1.1", title="Write tests", details="Write unit tests in test_foo.py")
+        assert sub.details == ["Write unit tests in test_foo.py"]
+
+    def test_list_unchanged(self) -> None:
+        sub = Subtask(id="1.1", title="Write tests", details=["step one", "step two"])
+        assert sub.details == ["step one", "step two"]
+
+    def test_empty_list_unchanged(self) -> None:
+        sub = Subtask(id="1.1", title="Write tests", details=[])
+        assert sub.details == []
+
+    def test_default_is_empty_list(self) -> None:
+        sub = Subtask(id="1.1", title="Write tests")
+        assert sub.details == []
+
+    def test_model_validate_with_string_details(self) -> None:
+        data = {
+            "id": "1.1",
+            "title": "Write tests",
+            "details": "Write unit tests in test_foo.py covering edge cases",
+        }
+        sub = Subtask.model_validate(data)
+        assert sub.details == ["Write unit tests in test_foo.py covering edge cases"]
+
+    def test_model_validate_nested_in_task_group(self) -> None:
+        from afspec import TaskGroup
+
+        data = {
+            "id": 1,
+            "title": "Implementation",
+            "subtasks": [
+                {"id": "1.1", "title": "Do thing", "details": "A single string detail"},
+                {"id": "1.2", "title": "Other thing", "details": ["Already", "a list"]},
+            ],
+        }
+        tg = TaskGroup.model_validate(data)
+        assert tg.subtasks[0].details == ["A single string detail"]
+        assert tg.subtasks[1].details == ["Already", "a list"]


### PR DESCRIPTION
## Summary

Added a Pydantic `field_validator` with `mode="before"` on `Subtask.details` that coerces a bare string into a single-element list. This fixes `spec generate` consistently failing on the `tasks` artifact because the LLM produces `details` as a string instead of `list[str]`, causing a `PydanticValidationError` before the repair flow can run.

Closes #658

## Changes

| File | Change |
|------|--------|
| `packages/afspec/afspec/models.py` | Added `field_validator("details", mode="before")` on `Subtask` to coerce `str → [str]` |
| `packages/afspec/tests/test_models.py` | Added 6 tests covering string coercion, list passthrough, empty list, default, `model_validate`, and nested `TaskGroup` deserialization |

## Tests

- `TestSubtaskDetailsCoercion::test_string_coerced_to_list` — bare string becomes single-element list
- `TestSubtaskDetailsCoercion::test_list_unchanged` — existing list input passes through
- `TestSubtaskDetailsCoercion::test_empty_list_unchanged` — empty list preserved
- `TestSubtaskDetailsCoercion::test_default_is_empty_list` — default factory unaffected
- `TestSubtaskDetailsCoercion::test_model_validate_with_string_details` — `model_validate` coerces string
- `TestSubtaskDetailsCoercion::test_model_validate_nested_in_task_group` — works through nested `TaskGroup`

## Verification

- All existing tests pass: ✅ (5731 passing, same 14 pre-existing failures)
- New tests pass: ✅ (6/6)
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*