### PR TITLE
fix(knowledge): inject drift findings into coder sessions (fixes #671)

### DIFF
--- a/packages/agentfox/agentfox/knowledge/formatting.py
+++ b/packages/agentfox/agentfox/knowledge/formatting.py
@@ -110,6 +110,23 @@ def format_finding_parts(finding: Any) -> str:
     return " ".join(parts)
 
 
+def format_drift_finding_parts(finding: Any) -> str:
+    """Format a drift finding's severity, refs, and description into a text fragment.
+
+    Returns a string like ``[critical] spec_ref (artifact_ref): description``.
+    """
+    parts = [f"[{finding.severity}]"]
+    refs = []
+    if finding.spec_ref:
+        refs.append(finding.spec_ref)
+    if finding.artifact_ref:
+        refs.append(finding.artifact_ref)
+    if refs:
+        parts.append(f"{' '.join(refs)}:")
+    parts.append(finding.description)
+    return " ".join(parts)
+
+
 def format_verdict_parts(verdict: Any) -> str:
     """Format a verdict's requirement ID and evidence into a text fragment.
 

--- a/packages/agentfox/agentfox/knowledge/fox_provider.py
+++ b/packages/agentfox/agentfox/knowledge/fox_provider.py
@@ -209,9 +209,12 @@ class FoxKnowledgeProvider:
             conn, spec_name, task_group=task_group, task_description=task_description
         )
 
-        # Build a parallel list of (text, review_id) so we can track which
-        # finding IDs survive the max_items cap.
-        items_with_ids: list[tuple[str, str]] = list(zip(reviews, review_ids))
+        drift, drift_ids = self._query_drift(conn, spec_name, task_group=task_group, task_description=task_description)
+
+        # Build a parallel list of (text, finding_id) so we can track which
+        # finding IDs survive the max_items cap.  Review and drift findings
+        # share the same cap and injection lifecycle.
+        items_with_ids: list[tuple[str, str]] = list(zip(reviews, review_ids)) + list(zip(drift, drift_ids))
 
         # Cross-group items: findings from other task groups in the same spec.
         # These are informational (not tracked for injection) and have their
@@ -229,8 +232,9 @@ class FoxKnowledgeProvider:
         result.extend(same_spec_summaries)
 
         logger.debug(
-            "Retrieved %d review + %d cross-group + %d context items for %s",
+            "Retrieved %d review + %d drift + %d cross-group + %d context items for %s",
             len(reviews),
+            len(drift),
             len(cross_group_items),
             len(same_spec_summaries),
             spec_name,
@@ -428,6 +432,43 @@ class FoxKnowledgeProvider:
         for f in actionable:
             result.append(f"[CROSS-GROUP] (group {f.task_group}) {format_finding_parts(f)}")
         return result
+
+    def _query_drift(
+        self,
+        conn: Any,
+        spec_name: str,
+        task_group: str | None = None,
+        task_description: str = "",
+    ) -> tuple[list[str], list[str]]:
+        """Query unresolved critical/major drift findings for the spec.
+
+        Mirrors ``_query_reviews()`` but queries ``drift_findings`` via
+        ``query_active_drift_findings()``.  Returns ``(formatted_strings,
+        finding_ids)`` for injection tracking.
+        """
+        include_prereview = task_group is not None and task_group != "0"
+
+        def _do_query():
+            from agentfox.knowledge.review_store import query_active_drift_findings
+
+            return query_active_drift_findings(
+                conn, spec_name, task_group=task_group, include_prereview=include_prereview
+            )
+
+        findings = _query_safe(_do_query, (), label="drift findings", spec_name=spec_name)
+
+        keywords = _extract_keywords(task_description)
+        actionable = [f for f in findings if f.severity in ("critical", "major")]
+        actionable = sort_findings(actionable, keywords)
+
+        from agentfox.knowledge.formatting import format_drift_finding_parts
+
+        result: list[str] = []
+        ids: list[str] = []
+        for f in actionable:
+            result.append(f"[DRIFT] {format_drift_finding_parts(f)}")
+            ids.append(f.id)
+        return result, ids
 
     # ------------------------------------------------------------------
     # Session summary helpers (spec 119)

--- a/packages/agentfox/agentfox/knowledge/review_store.py
+++ b/packages/agentfox/agentfox/knowledge/review_store.py
@@ -585,12 +585,12 @@ def supersede_injected_findings(
     conn: duckdb.DuckDBPyConnection,
     session_id: str,
 ) -> None:
-    """Supersede all review findings injected into a completed session.
+    """Supersede all findings (review and drift) injected into a completed session.
 
     Looks up the finding_injections table for the given session_id, then marks
-    each referenced row in ``review_findings`` as superseded (sets
-    ``superseded_by`` to the session_id string).  Only rows that are still
-    active (``superseded_by IS NULL``) are updated.
+    each referenced row in both ``review_findings`` and ``drift_findings`` as
+    superseded (sets ``superseded_by`` to the session_id string).  Only rows
+    that are still active (``superseded_by IS NULL``) are updated.
 
     A missing ``finding_injections`` table (pre-v23 DB) raises no exception —
     the caller is responsible for catching and logging the error.
@@ -611,6 +611,10 @@ def supersede_injected_findings(
     for finding_id in finding_ids:
         conn.execute(
             "UPDATE review_findings SET superseded_by = ? WHERE id::VARCHAR = ? AND superseded_by IS NULL",
+            [marker, finding_id],
+        )
+        conn.execute(
+            "UPDATE drift_findings SET superseded_by = ? WHERE id::VARCHAR = ? AND superseded_by IS NULL",
             [marker, finding_id],
         )
 

--- a/packages/agentfox/tests/spec/test_10_fox_provider_cleanup.py
+++ b/packages/agentfox/tests/spec/test_10_fox_provider_cleanup.py
@@ -225,16 +225,16 @@ class TestCrossGroupItemsReviewsOnly:
 
 
 # ---------------------------------------------------------------------------
-# TS-10-11: retrieve() log line matches three-field format
+# TS-10-11: retrieve() log line matches four-field format
 # ---------------------------------------------------------------------------
 
 
 class TestRetrieveLogFormat:
     """TS-10-11: Log message has exactly three item-count fields."""
 
-    def test_log_format_three_fields(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_log_format_four_fields(self, caplog: pytest.LogCaptureFixture) -> None:
         """The log line must match:
-        'Retrieved {N} review + {N} cross-group + {N} context items for {spec}'
+        'Retrieved {N} review + {N} drift + {N} cross-group + {N} context items for {spec}'
         """
         conn = _migrated_conn()
         provider = _make_provider(conn)
@@ -245,8 +245,8 @@ class TestRetrieveLogFormat:
         log_lines = [r.message for r in caplog.records if "Retrieved" in r.message and "items for" in r.message]
         assert len(log_lines) == 1, f"Expected exactly one 'Retrieved ... items for ...' log line, got {len(log_lines)}"
 
-        pattern = r"Retrieved \d+ review \+ \d+ cross-group \+ \d+ context items for my-spec"
-        assert re.search(pattern, log_lines[0]), f"Log line does not match three-field format:\n  {log_lines[0]}"
+        pattern = r"Retrieved \d+ review \+ \d+ drift \+ \d+ cross-group \+ \d+ context items for my-spec"
+        assert re.search(pattern, log_lines[0]), f"Log line does not match four-field format:\n  {log_lines[0]}"
         conn.close()
 
 
@@ -282,7 +282,7 @@ class TestNoVerdictIdsInInit:
 
 
 class TestLogFormatProperty:
-    """TS-10-P3: For any retrieve() invocation, log matches three-field format."""
+    """TS-10-P3: For any retrieve() invocation, log matches four-field format."""
 
     @pytest.mark.parametrize(
         "scenario",
@@ -322,8 +322,8 @@ class TestLogFormatProperty:
         matching = [r.message for r in caplog.records if "Retrieved" in r.message]
         assert len(matching) == 1
 
-        pattern = r"Retrieved \d+ review \+ \d+ cross-group \+ \d+ context items for test-spec"
-        assert re.search(pattern, matching[0]), f"Log line does not match three-field pattern:\n  {matching[0]}"
+        pattern = r"Retrieved \d+ review \+ \d+ drift \+ \d+ cross-group \+ \d+ context items for test-spec"
+        assert re.search(pattern, matching[0]), f"Log line does not match four-field pattern:\n  {matching[0]}"
         conn.close()
 
 
@@ -382,9 +382,9 @@ class TestSmokeThreeChannelRetrieval:
         for tag in removed_tags:
             assert tag not in prompt, f"Removed tag {tag} found in smoke retrieval"
 
-        # Log line must match three-field format
+        # Log line must match four-field format
         matching = [r.message for r in caplog.records if "Retrieved" in r.message]
         assert len(matching) == 1
-        pattern = r"Retrieved \d+ review \+ \d+ cross-group \+ \d+ context items for smoke-spec"
-        assert re.search(pattern, matching[0]), f"Smoke log line doesn't match three-field format: {matching[0]}"
+        pattern = r"Retrieved \d+ review \+ \d+ drift \+ \d+ cross-group \+ \d+ context items for smoke-spec"
+        assert re.search(pattern, matching[0]), f"Smoke log line doesn't match four-field format: {matching[0]}"
         conn.close()


### PR DESCRIPTION
## Summary

Drift findings from drift-review sessions were stored but never injected into downstream coder sessions. Coders independently rediscovered issues the drift reviewer had already found.

Closes #671

## Changes

| File | Change |
|------|--------|
| `packages/agentfox/agentfox/knowledge/fox_provider.py` | Added `_query_drift()`, wired into `retrieve()` alongside review findings |
| `packages/agentfox/agentfox/knowledge/review_store.py` | `supersede_injected_findings()` now UPDATEs both `review_findings` and `drift_findings` |
| `packages/agentfox/agentfox/knowledge/formatting.py` | Added `format_drift_finding_parts()` for drift-specific fields |
| `packages/agentfox/tests/spec/test_10_fox_provider_cleanup.py` | Updated log format assertions (3-field → 4-field) |

## Verification

- All existing tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*